### PR TITLE
Change over to using operator[]

### DIFF
--- a/core/extension/gdnative_interface.cpp
+++ b/core/extension/gdnative_interface.cpp
@@ -783,6 +783,18 @@ static GDNativeVariantPtr gdnative_array_operator_index_const(const GDNativeType
 	return (GDNativeVariantPtr)&self->operator[](p_index);
 }
 
+/* Dictionary functions */
+
+static GDNativeVariantPtr gdnative_dictionary_operator_index(GDNativeTypePtr p_self, const GDNativeVariantPtr p_key) {
+	Dictionary *self = (Dictionary *)p_self;
+	return (GDNativeTypePtr)self->getptr(*(const Variant *)p_key);
+}
+
+static GDNativeVariantPtr gdnative_dictionary_operator_index_const(const GDNativeTypePtr p_self, const GDNativeVariantPtr p_key) {
+	const Dictionary *self = (const Dictionary *)p_self;
+	return (GDNativeTypePtr)self->getptr(*(const Variant *)p_key);
+}
+
 /* OBJECT API */
 
 static void gdnative_object_method_bind_call(const GDNativeMethodBindPtr p_method_bind, GDNativeObjectPtr p_instance, const GDNativeVariantPtr *p_args, GDNativeInt p_arg_count, GDNativeVariantPtr r_return, GDNativeCallError *r_error) {
@@ -1000,6 +1012,11 @@ void gdnative_setup_interface(GDNativeInterface *p_interface) {
 
 	gdni.array_operator_index = gdnative_array_operator_index;
 	gdni.array_operator_index_const = gdnative_array_operator_index_const;
+
+	/* Dictionary functions */
+
+	gdni.dictionary_operator_index = gdnative_dictionary_operator_index;
+	gdni.dictionary_operator_index_const = gdnative_dictionary_operator_index_const;
 
 	/* OBJECT */
 

--- a/core/extension/gdnative_interface.cpp
+++ b/core/extension/gdnative_interface.cpp
@@ -787,12 +787,12 @@ static GDNativeVariantPtr gdnative_array_operator_index_const(const GDNativeType
 
 static GDNativeVariantPtr gdnative_dictionary_operator_index(GDNativeTypePtr p_self, const GDNativeVariantPtr p_key) {
 	Dictionary *self = (Dictionary *)p_self;
-	return (GDNativeTypePtr)self->getptr(*(const Variant *)p_key);
+	return (GDNativeVariantPtr)&self->operator[](*(const Variant *)p_key);
 }
 
 static GDNativeVariantPtr gdnative_dictionary_operator_index_const(const GDNativeTypePtr p_self, const GDNativeVariantPtr p_key) {
 	const Dictionary *self = (const Dictionary *)p_self;
-	return (GDNativeTypePtr)self->getptr(*(const Variant *)p_key);
+	return (GDNativeVariantPtr)&self->operator[](*(const Variant *)p_key);
 }
 
 /* OBJECT API */

--- a/core/extension/gdnative_interface.h
+++ b/core/extension/gdnative_interface.h
@@ -417,6 +417,11 @@ typedef struct {
 	GDNativeVariantPtr (*array_operator_index)(GDNativeTypePtr p_self, GDNativeInt p_index); // p_self should be an Array ptr
 	GDNativeVariantPtr (*array_operator_index_const)(const GDNativeTypePtr p_self, GDNativeInt p_index); // p_self should be an Array ptr
 
+	/* Dictionary functions */
+
+	GDNativeVariantPtr (*dictionary_operator_index)(GDNativeTypePtr p_self, const GDNativeVariantPtr p_key); // p_self should be an Dictionary ptr
+	GDNativeVariantPtr (*dictionary_operator_index_const)(const GDNativeTypePtr p_self, const GDNativeVariantPtr p_key); // p_self should be an Dictionary ptr
+
 	/* OBJECT */
 
 	void (*object_method_bind_call)(const GDNativeMethodBindPtr p_method_bind, GDNativeObjectPtr p_instance, const GDNativeVariantPtr *p_args, GDNativeInt p_arg_count, GDNativeVariantPtr r_ret, GDNativeCallError *r_error);


### PR DESCRIPTION
@bruvzg `getptr()` doesn't add a new entry for an unknown key and thus crashes extensions when you use it, `operator[]` does.

i've got the changes for GDExtensions here: https://github.com/godotengine/godot-cpp/pull/656

At this point it correctly modifies the dictionary but returning it to Godot fails because it gets freed. any ideas?