### PR TITLE
Add double-click maximise support to the x11 displayserver for the move decoration

### DIFF
--- a/doc/classes/DisplayServer.xml
+++ b/doc/classes/DisplayServer.xml
@@ -1224,11 +1224,30 @@
 				[b]Note:[/b] [method warp_mouse] is only supported on Windows, macOS and Linux. It has no effect on Android, iOS and Web.
 			</description>
 		</method>
+		<method name="window_add_decoration">
+			<return type="int" />
+			<param index="0" name="region" type="PackedVector2Array" />
+			<param index="1" name="dec_type" type="int" enum="DisplayServer.WindowDecorationType" />
+			<param index="2" name="window" type="int" default="0" />
+			<description>
+				Adds polygon which should act as window move / resize region specified by [param dec_type].
+			</description>
+		</method>
 		<method name="window_can_draw" qualifiers="const">
 			<return type="bool" />
 			<param index="0" name="window_id" type="int" default="0" />
 			<description>
 				Returns [code]true[/code] if anything can be drawn in the window specified by [param window_id], [code]false[/code] otherwise. Using the [code]--disable-render-loop[/code] command line argument or a headless build will return [code]false[/code].
+			</description>
+		</method>
+		<method name="window_change_decoration">
+			<return type="void" />
+			<param index="0" name="rect_id" type="int" />
+			<param index="1" name="region" type="PackedVector2Array" />
+			<param index="2" name="dec_type" type="int" enum="DisplayServer.WindowDecorationType" />
+			<param index="3" name="window" type="int" default="0" />
+			<description>
+				Changes type and polygon of the move / resize region created using [method window_add_decoration].
 			</description>
 		</method>
 		<method name="window_get_active_popup" qualifiers="const">
@@ -1380,6 +1399,14 @@
 			<param index="0" name="window_id" type="int" default="0" />
 			<description>
 				Moves the window specified by [param window_id] to the foreground, so that it is visible over other windows.
+			</description>
+		</method>
+		<method name="window_remove_decoration">
+			<return type="void" />
+			<param index="0" name="rect_id" type="int" />
+			<param index="1" name="window" type="int" default="0" />
+			<description>
+				Removes move / resize region created using [method window_add_decoration].
 			</description>
 		</method>
 		<method name="window_request_attention">
@@ -1681,6 +1708,9 @@
 		<constant name="FEATURE_SCREEN_CAPTURE" value="21" enum="Feature">
 			Display server supports reading screen pixels. See [method screen_get_pixel].
 		</constant>
+		<constant name="FEATURE_CLIENT_SIDE_DECORATIONS" value="22" enum="Feature">
+			Display server supports client side decorations. See [method window_add_decoration], [method window_change_decoration], and [method window_remove_decoration].
+		</constant>
 		<constant name="MOUSE_MODE_VISIBLE" value="0" enum="MouseMode">
 			Makes the mouse cursor visible if it is hidden.
 		</constant>
@@ -1912,6 +1942,33 @@
 		<constant name="WINDOW_EVENT_TITLEBAR_CHANGE" value="7" enum="WindowEvent">
 			Sent when the window title bar decoration is changed (e.g. [constant WINDOW_FLAG_EXTEND_TO_TITLE] is set or window entered/exited full screen mode).
 			[b]Note:[/b] This flag is implemented only on macOS.
+		</constant>
+		<constant name="WINDOW_DECORATION_TOP_LEFT" value="0" enum="WindowDecorationType">
+			Window top-left resize element.
+		</constant>
+		<constant name="WINDOW_DECORATION_TOP" value="1" enum="WindowDecorationType">
+			Window top resize element.
+		</constant>
+		<constant name="WINDOW_DECORATION_TOP_RIGHT" value="2" enum="WindowDecorationType">
+			Window top-right resize element.
+		</constant>
+		<constant name="WINDOW_DECORATION_LEFT" value="3" enum="WindowDecorationType">
+			Window left resize element.
+		</constant>
+		<constant name="WINDOW_DECORATION_RIGHT" value="4" enum="WindowDecorationType">
+			Window right resize element.
+		</constant>
+		<constant name="WINDOW_DECORATION_BOTTOM_LEFT" value="5" enum="WindowDecorationType">
+			Window bottom-left resize element.
+		</constant>
+		<constant name="WINDOW_DECORATION_BOTTOM" value="6" enum="WindowDecorationType">
+			Window bottom resize element.
+		</constant>
+		<constant name="WINDOW_DECORATION_BOTTOM_RIGHT" value="7" enum="WindowDecorationType">
+			Window bottom-right resize element.
+		</constant>
+		<constant name="WINDOW_DECORATION_MOVE" value="8" enum="WindowDecorationType">
+			Window move element.
 		</constant>
 		<constant name="VSYNC_DISABLED" value="0" enum="VSyncMode">
 			No vertical synchronization, which means the engine will display frames as fast as possible (tearing may be visible). Framerate is unlimited (notwithstanding [member Engine.max_fps]).

--- a/doc/classes/WindowDecoration.xml
+++ b/doc/classes/WindowDecoration.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<class name="WindowDecoration" inherits="Control" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../class.xsd">
+	<brief_description>
+		A move / resize region for the native [Window].
+	</brief_description>
+	<description>
+		A move / resize region, used to implement client side decorations for the native [Window].
+	</description>
+	<tutorials>
+	</tutorials>
+	<members>
+		<member name="decoration_type" type="int" setter="set_decoration_type" getter="get_decoration_type" enum="DisplayServer.WindowDecorationType" default="8">
+			Move / resize region type.
+		</member>
+		<member name="non_rectangular_region" type="bool" setter="set_non_rectangular_region" getter="is_non_rectangular_region" default="false">
+			If [code]true[/code], polygonal region is used instead of control bounds.
+		</member>
+		<member name="polygon" type="PackedVector2Array" setter="set_polygon" getter="get_polygon" default="PackedVector2Array()">
+			The region's list of vertices. The final point will be connected to the first.
+			[b]Note:[/b] Used only if [member non_rectangular_region] is [code]true[/code].
+			[b]Note:[/b] This returns a copy of the [PackedVector2Array] rather than a reference.
+		</member>
+	</members>
+</class>

--- a/editor/gui/editor_title_bar.cpp
+++ b/editor/gui/editor_title_bar.cpp
@@ -30,55 +30,84 @@
 
 #include "editor_title_bar.h"
 
-void EditorTitleBar::gui_input(const Ref<InputEvent> &p_event) {
-	if (!can_move) {
+void EditorTitleBar::_update_rects() {
+	if (!is_inside_tree()) {
+		return;
+	}
+	if (!DisplayServer::get_singleton()) {
+		return;
+	}
+	if (!DisplayServer::get_singleton()->has_feature(DisplayServer::FEATURE_CLIENT_SIDE_DECORATIONS)) {
 		return;
 	}
 
-	Ref<InputEventMouseMotion> mm = p_event;
-	if (mm.is_valid() && moving) {
-		if (mm->get_button_mask().has_flag(MouseButtonMask::LEFT)) {
-			Window *w = Object::cast_to<Window>(get_viewport());
-			if (w) {
-				Point2 mouse = DisplayServer::get_singleton()->mouse_get_position();
-				w->set_position(mouse - click_pos);
-			}
-		} else {
-			moving = false;
-		}
+	DisplayServer::WindowID wid = get_viewport()->get_window_id();
+	for (int &id : ids) {
+		DisplayServer::get_singleton()->window_remove_decoration(id, wid);
 	}
+	ids.clear();
 
-	Ref<InputEventMouseButton> mb = p_event;
-	if (mb.is_valid() && has_point(mb->get_position())) {
-		Window *w = Object::cast_to<Window>(get_viewport());
-		if (w) {
-			if (mb->get_button_index() == MouseButton::LEFT) {
-				if (mb->is_pressed()) {
-					click_pos = DisplayServer::get_singleton()->mouse_get_position() - w->get_position();
-					moving = true;
-				} else {
-					moving = false;
-				}
+	if (can_move) {
+		Vector<Rect2i> rects;
+		int prev_pos = 0;
+		int count = get_child_count();
+		for (int i = 0; i < count; i++) {
+			Control *n = Object::cast_to<Control>(get_child(i));
+			if (n && n->get_mouse_filter() != Control::MOUSE_FILTER_PASS) {
+				int start = n->get_position().x;
+				rects.push_back(Rect2(prev_pos, 0, start - prev_pos, get_size().y));
+				prev_pos = start + n->get_size().x;
 			}
-			if (mb->get_button_index() == MouseButton::LEFT && mb->is_double_click() && mb->is_pressed()) {
-				if (DisplayServer::get_singleton()->window_maximize_on_title_dbl_click()) {
-					if (w->get_mode() == Window::MODE_WINDOWED) {
-						w->set_mode(Window::MODE_MAXIMIZED);
-					} else if (w->get_mode() == Window::MODE_MAXIMIZED) {
-						w->set_mode(Window::MODE_WINDOWED);
-					}
-				} else if (DisplayServer::get_singleton()->window_minimize_on_title_dbl_click()) {
-					w->set_mode(Window::MODE_MINIMIZED);
-				}
-				moving = false;
+		}
+		if (prev_pos != 0) {
+			rects.push_back(Rect2(prev_pos, 0, get_size().x - prev_pos, get_size().y));
+		}
+
+		for (Rect2i &rect : rects) {
+			Vector<Point2> polygon_global;
+			polygon_global.push_back(rect.position);
+			polygon_global.push_back(rect.position + Vector2(rect.size.x, 0));
+			polygon_global.push_back(rect.position + rect.size);
+			polygon_global.push_back(rect.position + Vector2(0, rect.size.y));
+
+			Transform2D t = get_global_transform();
+			for (Vector2 &E : polygon_global) {
+				E = t.xform(E);
 			}
+			int id = DisplayServer::get_singleton()->window_add_decoration(polygon_global, DisplayServer::WINDOW_DECORATION_MOVE, wid);
+			ids.push_back(id);
 		}
 	}
 }
 
+void EditorTitleBar::_notification(int p_notification) {
+	switch (p_notification) {
+		case NOTIFICATION_CHILD_ORDER_CHANGED:
+		case NOTIFICATION_RESIZED:
+		case NOTIFICATION_ENTER_TREE: {
+			_update_rects();
+		} break;
+		case NOTIFICATION_EXIT_TREE: {
+			if (!DisplayServer::get_singleton()) {
+				return;
+			}
+			if (!DisplayServer::get_singleton()->has_feature(DisplayServer::FEATURE_CLIENT_SIDE_DECORATIONS)) {
+				return;
+			}
+			DisplayServer::WindowID wid = get_viewport()->get_window_id();
+			for (int &id : ids) {
+				DisplayServer::get_singleton()->window_remove_decoration(id, wid);
+			}
+			ids.clear();
+		} break;
+	}
+}
+
 void EditorTitleBar::set_can_move_window(bool p_enabled) {
-	can_move = p_enabled;
-	set_process_input(can_move);
+	if (can_move != p_enabled) {
+		can_move = p_enabled;
+		_update_rects();
+	}
 }
 
 bool EditorTitleBar::get_can_move_window() const {

--- a/editor/gui/editor_title_bar.h
+++ b/editor/gui/editor_title_bar.h
@@ -37,12 +37,13 @@
 class EditorTitleBar : public HBoxContainer {
 	GDCLASS(EditorTitleBar, HBoxContainer);
 
-	Point2i click_pos;
-	bool moving = false;
+	Vector<int> ids;
 	bool can_move = false;
 
+	void _update_rects();
+
 protected:
-	virtual void gui_input(const Ref<InputEvent> &p_event) override;
+	void _notification(int p_notification);
 	static void _bind_methods(){};
 
 public:

--- a/editor/icons/WindowDecoration.svg
+++ b/editor/icons/WindowDecoration.svg
@@ -1,0 +1,1 @@
+<svg height="16" viewBox="0 0 16 16" width="16" xmlns="http://www.w3.org/2000/svg"><path d="M3 1a2 2 0 0 0-2 2v1h14V3a2 2 0 0 0-2-2H3zm9 1h1v1h-1V2zM1.018 4.99v2h2v-2h-2zm12 0v2h2v-2h-2zm-12 4v2h2v-2h-2zm12 0v2h2v-2h-2zm-12 4a2 2 0 0 0 2 2v-2h-2zm4 0v2h2v-2h-2zm4 0v2h2v-2h-2zm4 0v2a2 2 0 0 0 2-2h-2z" fill="#e0e0e0"/></svg>

--- a/editor/plugins/abstract_polygon_2d_editor.cpp
+++ b/editor/plugins/abstract_polygon_2d_editor.cpp
@@ -93,7 +93,7 @@ void AbstractPolygon2DEditor::_set_polygon(int p_idx, const Variant &p_polygon) 
 }
 
 void AbstractPolygon2DEditor::_action_set_polygon(int p_idx, const Variant &p_previous, const Variant &p_polygon) {
-	Node2D *node = _get_node();
+	CanvasItem *node = _get_node();
 	EditorUndoRedoManager *undo_redo = EditorUndoRedoManager::get_singleton();
 	undo_redo->add_do_method(node, "set_polygon", p_polygon);
 	undo_redo->add_undo_method(node, "set_polygon", p_previous);

--- a/editor/plugins/abstract_polygon_2d_editor.h
+++ b/editor/plugins/abstract_polygon_2d_editor.h
@@ -117,7 +117,7 @@ protected:
 
 	bool _is_empty() const;
 
-	virtual Node2D *_get_node() const = 0;
+	virtual CanvasItem *_get_node() const = 0;
 	virtual void _set_node(Node *p_polygon) = 0;
 
 	virtual bool _is_line() const;

--- a/editor/plugins/collision_polygon_2d_editor_plugin.cpp
+++ b/editor/plugins/collision_polygon_2d_editor_plugin.cpp
@@ -30,7 +30,7 @@
 
 #include "collision_polygon_2d_editor_plugin.h"
 
-Node2D *CollisionPolygon2DEditor::_get_node() const {
+CanvasItem *CollisionPolygon2DEditor::_get_node() const {
 	return node;
 }
 

--- a/editor/plugins/collision_polygon_2d_editor_plugin.h
+++ b/editor/plugins/collision_polygon_2d_editor_plugin.h
@@ -40,7 +40,7 @@ class CollisionPolygon2DEditor : public AbstractPolygon2DEditor {
 	CollisionPolygon2D *node = nullptr;
 
 protected:
-	virtual Node2D *_get_node() const override;
+	virtual CanvasItem *_get_node() const override;
 	virtual void _set_node(Node *p_polygon) override;
 
 public:

--- a/editor/plugins/light_occluder_2d_editor_plugin.cpp
+++ b/editor/plugins/light_occluder_2d_editor_plugin.cpp
@@ -42,7 +42,7 @@ Ref<OccluderPolygon2D> LightOccluder2DEditor::_ensure_occluder() const {
 	return occluder;
 }
 
-Node2D *LightOccluder2DEditor::_get_node() const {
+CanvasItem *LightOccluder2DEditor::_get_node() const {
 	return node;
 }
 

--- a/editor/plugins/light_occluder_2d_editor_plugin.h
+++ b/editor/plugins/light_occluder_2d_editor_plugin.h
@@ -42,7 +42,7 @@ class LightOccluder2DEditor : public AbstractPolygon2DEditor {
 	Ref<OccluderPolygon2D> _ensure_occluder() const;
 
 protected:
-	virtual Node2D *_get_node() const override;
+	virtual CanvasItem *_get_node() const override;
 	virtual void _set_node(Node *p_polygon) override;
 
 	virtual bool _is_line() const override;

--- a/editor/plugins/line_2d_editor_plugin.h
+++ b/editor/plugins/line_2d_editor_plugin.h
@@ -40,7 +40,7 @@ class Line2DEditor : public AbstractPolygon2DEditor {
 	Line2D *node = nullptr;
 
 protected:
-	virtual Node2D *_get_node() const override;
+	virtual CanvasItem *_get_node() const override;
 	virtual void _set_node(Node *p_line) override;
 
 	virtual bool _is_line() const override;

--- a/editor/plugins/navigation_obstacle_2d_editor_plugin.cpp
+++ b/editor/plugins/navigation_obstacle_2d_editor_plugin.cpp
@@ -33,7 +33,7 @@
 #include "editor/editor_node.h"
 #include "editor/editor_undo_redo_manager.h"
 
-Node2D *NavigationObstacle2DEditor::_get_node() const {
+CanvasItem *NavigationObstacle2DEditor::_get_node() const {
 	return node;
 }
 

--- a/editor/plugins/navigation_obstacle_2d_editor_plugin.h
+++ b/editor/plugins/navigation_obstacle_2d_editor_plugin.h
@@ -40,7 +40,7 @@ class NavigationObstacle2DEditor : public AbstractPolygon2DEditor {
 	NavigationObstacle2D *node = nullptr;
 
 protected:
-	virtual Node2D *_get_node() const override;
+	virtual CanvasItem *_get_node() const override;
 	virtual void _set_node(Node *p_polygon) override;
 
 	virtual void _action_add_polygon(const Variant &p_polygon) override;

--- a/editor/plugins/navigation_polygon_editor_plugin.cpp
+++ b/editor/plugins/navigation_polygon_editor_plugin.cpp
@@ -44,7 +44,7 @@ Ref<NavigationPolygon> NavigationPolygonEditor::_ensure_navpoly() const {
 	return navpoly;
 }
 
-Node2D *NavigationPolygonEditor::_get_node() const {
+CanvasItem *NavigationPolygonEditor::_get_node() const {
 	return node;
 }
 

--- a/editor/plugins/navigation_polygon_editor_plugin.h
+++ b/editor/plugins/navigation_polygon_editor_plugin.h
@@ -64,7 +64,7 @@ class NavigationPolygonEditor : public AbstractPolygon2DEditor {
 protected:
 	void _notification(int p_what);
 
-	virtual Node2D *_get_node() const override;
+	virtual CanvasItem *_get_node() const override;
 	virtual void _set_node(Node *p_polygon) override;
 
 	virtual int _get_polygon_count() const override;

--- a/editor/plugins/polygon_2d_editor_plugin.cpp
+++ b/editor/plugins/polygon_2d_editor_plugin.cpp
@@ -51,7 +51,7 @@
 #include "scene/gui/texture_rect.h"
 #include "scene/gui/view_panner.h"
 
-Node2D *Polygon2DEditor::_get_node() const {
+CanvasItem *Polygon2DEditor::_get_node() const {
 	return node;
 }
 

--- a/editor/plugins/polygon_2d_editor_plugin.h
+++ b/editor/plugins/polygon_2d_editor_plugin.h
@@ -162,7 +162,7 @@ class Polygon2DEditor : public AbstractPolygon2DEditor {
 	int _get_polygon_count() const override;
 
 protected:
-	virtual Node2D *_get_node() const override;
+	virtual CanvasItem *_get_node() const override;
 	virtual void _set_node(Node *p_polygon) override;
 
 	virtual Vector2 _get_offset(int p_idx) const override;

--- a/editor/plugins/window_decoration_editor_plugin.cpp
+++ b/editor/plugins/window_decoration_editor_plugin.cpp
@@ -1,5 +1,5 @@
 /**************************************************************************/
-/*  line_2d_editor_plugin.cpp                                             */
+/*  window_decoration_editor_plugin.cpp                                   */
 /**************************************************************************/
 /*                         This file is part of:                          */
 /*                             GODOT ENGINE                               */
@@ -28,40 +28,23 @@
 /* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
 /**************************************************************************/
 
-#include "line_2d_editor_plugin.h"
+#include "window_decoration_editor_plugin.h"
 
-#include "editor/editor_node.h"
-#include "editor/editor_undo_redo_manager.h"
-
-CanvasItem *Line2DEditor::_get_node() const {
+CanvasItem *WindowDecorationEditor::_get_node() const {
 	return node;
 }
 
-void Line2DEditor::_set_node(Node *p_line) {
-	node = Object::cast_to<Line2D>(p_line);
+void WindowDecorationEditor::_set_node(Node *p_polygon) {
+	WindowDecoration *wd = Object::cast_to<WindowDecoration>(p_polygon);
+	if (wd && wd->is_non_rectangular_region()) {
+		node = wd;
+	} else {
+		node = nullptr;
+	}
 }
 
-bool Line2DEditor::_is_line() const {
-	return true;
-}
+WindowDecorationEditor::WindowDecorationEditor() {}
 
-Variant Line2DEditor::_get_polygon(int p_idx) const {
-	return _get_node()->get("points");
-}
-
-void Line2DEditor::_set_polygon(int p_idx, const Variant &p_polygon) const {
-	_get_node()->set("points", p_polygon);
-}
-
-void Line2DEditor::_action_set_polygon(int p_idx, const Variant &p_previous, const Variant &p_polygon) {
-	CanvasItem *_node = _get_node();
-	EditorUndoRedoManager *undo_redo = EditorUndoRedoManager::get_singleton();
-	undo_redo->add_do_method(_node, "set_points", p_polygon);
-	undo_redo->add_undo_method(_node, "set_points", p_previous);
-}
-
-Line2DEditor::Line2DEditor() {}
-
-Line2DEditorPlugin::Line2DEditorPlugin() :
-		AbstractPolygon2DEditorPlugin(memnew(Line2DEditor), "Line2D") {
+WindowDecorationEditorPlugin::WindowDecorationEditorPlugin() :
+		AbstractPolygon2DEditorPlugin(memnew(WindowDecorationEditor), "WindowDecoration") {
 }

--- a/editor/plugins/window_decoration_editor_plugin.h
+++ b/editor/plugins/window_decoration_editor_plugin.h
@@ -1,5 +1,5 @@
 /**************************************************************************/
-/*  line_2d_editor_plugin.cpp                                             */
+/*  window_decoration_editor_plugin.h                                     */
 /**************************************************************************/
 /*                         This file is part of:                          */
 /*                             GODOT ENGINE                               */
@@ -28,40 +28,30 @@
 /* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
 /**************************************************************************/
 
-#include "line_2d_editor_plugin.h"
+#ifndef WINDOW_DECORATION_EDITOR_PLUGIN_H
+#define WINDOW_DECORATION_EDITOR_PLUGIN_H
 
-#include "editor/editor_node.h"
-#include "editor/editor_undo_redo_manager.h"
+#include "editor/plugins/abstract_polygon_2d_editor.h"
+#include "scene/gui/window_decoration.h"
 
-CanvasItem *Line2DEditor::_get_node() const {
-	return node;
-}
+class WindowDecorationEditor : public AbstractPolygon2DEditor {
+	GDCLASS(WindowDecorationEditor, AbstractPolygon2DEditor);
 
-void Line2DEditor::_set_node(Node *p_line) {
-	node = Object::cast_to<Line2D>(p_line);
-}
+	WindowDecoration *node = nullptr;
 
-bool Line2DEditor::_is_line() const {
-	return true;
-}
+protected:
+	virtual CanvasItem *_get_node() const override;
+	virtual void _set_node(Node *p_polygon) override;
 
-Variant Line2DEditor::_get_polygon(int p_idx) const {
-	return _get_node()->get("points");
-}
+public:
+	WindowDecorationEditor();
+};
 
-void Line2DEditor::_set_polygon(int p_idx, const Variant &p_polygon) const {
-	_get_node()->set("points", p_polygon);
-}
+class WindowDecorationEditorPlugin : public AbstractPolygon2DEditorPlugin {
+	GDCLASS(WindowDecorationEditorPlugin, AbstractPolygon2DEditorPlugin);
 
-void Line2DEditor::_action_set_polygon(int p_idx, const Variant &p_previous, const Variant &p_polygon) {
-	CanvasItem *_node = _get_node();
-	EditorUndoRedoManager *undo_redo = EditorUndoRedoManager::get_singleton();
-	undo_redo->add_do_method(_node, "set_points", p_polygon);
-	undo_redo->add_undo_method(_node, "set_points", p_previous);
-}
+public:
+	WindowDecorationEditorPlugin();
+};
 
-Line2DEditor::Line2DEditor() {}
-
-Line2DEditorPlugin::Line2DEditorPlugin() :
-		AbstractPolygon2DEditorPlugin(memnew(Line2DEditor), "Line2D") {
-}
+#endif // WINDOW_DECORATION_EDITOR_PLUGIN_H

--- a/editor/register_editor_types.cpp
+++ b/editor/register_editor_types.cpp
@@ -126,6 +126,7 @@
 #include "editor/plugins/version_control_editor_plugin.h"
 #include "editor/plugins/visual_shader_editor_plugin.h"
 #include "editor/plugins/voxel_gi_editor_plugin.h"
+#include "editor/plugins/window_decoration_editor_plugin.h"
 #include "editor/register_exporters.h"
 
 void register_editor_types() {
@@ -259,6 +260,9 @@ void register_editor_types() {
 	EditorPlugins::add_by_type<Sprite2DEditorPlugin>();
 	EditorPlugins::add_by_type<TileSetEditorPlugin>();
 	EditorPlugins::add_by_type<TileMapEditorPlugin>();
+
+	// GUI
+	EditorPlugins::add_by_type<WindowDecorationEditorPlugin>();
 
 	// For correct doc generation.
 	GLOBAL_DEF("editor/run/main_run_args", "");

--- a/platform/linuxbsd/x11/display_server_x11.cpp
+++ b/platform/linuxbsd/x11/display_server_x11.cpp
@@ -36,6 +36,7 @@
 #include "x11/key_mapping_x11.h"
 
 #include "core/config/project_settings.h"
+#include "core/math/geometry_2d.h"
 #include "core/math/math_funcs.h"
 #include "core/string/print_string.h"
 #include "core/string/ustring.h"
@@ -69,6 +70,16 @@
 // EWMH
 #define _NET_WM_STATE_REMOVE 0L // remove/unset property
 #define _NET_WM_STATE_ADD 1L // add/set property
+
+#define _NET_WM_MOVERESIZE_SIZE_TOPLEFT 0L
+#define _NET_WM_MOVERESIZE_SIZE_TOP 1L
+#define _NET_WM_MOVERESIZE_SIZE_TOPRIGHT 2L
+#define _NET_WM_MOVERESIZE_SIZE_RIGHT 3L
+#define _NET_WM_MOVERESIZE_SIZE_BOTTOMRIGHT 4L
+#define _NET_WM_MOVERESIZE_SIZE_BOTTOM 5L
+#define _NET_WM_MOVERESIZE_SIZE_BOTTOMLEFT 6L
+#define _NET_WM_MOVERESIZE_SIZE_LEFT 7L
+#define _NET_WM_MOVERESIZE_MOVE 8L
 
 // 2.2 is the first release with multitouch
 #define XINPUT_CLIENT_VERSION_MAJOR 2
@@ -134,6 +145,7 @@ bool DisplayServerX11::has_feature(Feature p_feature) const {
 		case FEATURE_CLIPBOARD_PRIMARY:
 		case FEATURE_TEXT_TO_SPEECH:
 		case FEATURE_SCREEN_CAPTURE:
+		case FEATURE_CLIENT_SIDE_DECORATIONS:
 			return true;
 		default: {
 		}
@@ -1832,6 +1844,44 @@ void DisplayServerX11::window_set_mouse_passthrough(const Vector<Vector2> &p_reg
 	ERR_FAIL_COND(!windows.has(p_window));
 	windows[p_window].mpath = p_region;
 	_update_window_mouse_passthrough(p_window);
+}
+
+int DisplayServerX11::window_add_decoration(const Vector<Vector2> &p_region, DisplayServer::WindowDecorationType p_dec_type, WindowID p_window) {
+	_THREAD_SAFE_METHOD_
+
+	ERR_FAIL_INDEX_V(p_dec_type, DisplayServer::WINDOW_DECORATION_MAX, -1);
+	ERR_FAIL_COND_V(!windows.has(p_window), -1);
+	WindowData &wd = windows[p_window];
+
+	int did = wd.decor_id++;
+	wd.decor[did].region = p_region;
+	wd.decor[did].dec_type = p_dec_type;
+
+	return did;
+}
+
+void DisplayServerX11::window_change_decoration(int p_rect_id, const Vector<Vector2> &p_region, DisplayServer::WindowDecorationType p_dec_type, WindowID p_window) {
+	_THREAD_SAFE_METHOD_
+
+	ERR_FAIL_INDEX(p_dec_type, DisplayServer::WINDOW_DECORATION_MAX);
+	ERR_FAIL_COND(!windows.has(p_window));
+	WindowData &wd = windows[p_window];
+
+	if (wd.decor.has(p_rect_id)) {
+		wd.decor[p_rect_id].region = p_region;
+		wd.decor[p_rect_id].dec_type = p_dec_type;
+	}
+}
+
+void DisplayServerX11::window_remove_decoration(int p_rect_id, WindowID p_window) {
+	_THREAD_SAFE_METHOD_
+
+	ERR_FAIL_COND(!windows.has(p_window));
+	WindowData &wd = windows[p_window];
+
+	if (wd.decor.has(p_rect_id)) {
+		wd.decor.erase(p_rect_id);
+	}
 }
 
 void DisplayServerX11::_update_window_mouse_passthrough(WindowID p_window) {
@@ -4228,6 +4278,27 @@ bool DisplayServerX11::mouse_process_popups() {
 	return closed;
 }
 
+void DisplayServerX11::_process_window_drag(WindowID p_window, XEvent p_event, int p_dec_type) {
+	XClientMessageEvent m;
+	memset(&m, 0, sizeof(m));
+
+	XUngrabPointer(x11_display, CurrentTime);
+	XFlush(x11_display);
+
+	m.type = ClientMessage;
+	m.window = windows[p_window].x11_window;
+	m.message_type = XInternAtom(x11_display, "_NET_WM_MOVERESIZE", True);
+	m.format = 32;
+	m.data.l[0] = p_event.xbutton.x_root;
+	m.data.l[1] = p_event.xbutton.y_root;
+	m.data.l[2] = p_dec_type;
+	m.data.l[3] = Button1;
+
+	XSendEvent(x11_display, DefaultRootWindow(x11_display), False, SubstructureRedirectMask | SubstructureNotifyMask, (XEvent *)&m);
+
+	XSync(x11_display, 0);
+}
+
 void DisplayServerX11::process_events() {
 	_THREAD_SAFE_METHOD_
 
@@ -4682,7 +4753,60 @@ void DisplayServerX11::process_events() {
 				_window_changed(&event);
 			} break;
 
-			case ButtonPress:
+			case ButtonPress: {
+				if (event.xbutton.button == 1) {
+					bool drag_event = false;
+					for (const KeyValue<int, DisplayServerX11::DecorData> &E : windows[window_id].decor) {
+						if (Geometry2D::is_point_in_polygon(Vector2i(event.xbutton.x, event.xbutton.y), E.value.region)) {
+							switch (E.value.dec_type) {
+								case DisplayServer::WINDOW_DECORATION_TOP_LEFT: {
+									_process_window_drag(window_id, event, _NET_WM_MOVERESIZE_SIZE_TOPLEFT);
+									drag_event = true;
+								} break;
+								case DisplayServer::WINDOW_DECORATION_TOP: {
+									_process_window_drag(window_id, event, _NET_WM_MOVERESIZE_SIZE_TOP);
+									drag_event = true;
+								} break;
+								case DisplayServer::WINDOW_DECORATION_TOP_RIGHT: {
+									_process_window_drag(window_id, event, _NET_WM_MOVERESIZE_SIZE_TOPRIGHT);
+									drag_event = true;
+								} break;
+								case DisplayServer::WINDOW_DECORATION_LEFT: {
+									_process_window_drag(window_id, event, _NET_WM_MOVERESIZE_SIZE_LEFT);
+									drag_event = true;
+								} break;
+								case DisplayServer::WINDOW_DECORATION_RIGHT: {
+									_process_window_drag(window_id, event, _NET_WM_MOVERESIZE_SIZE_RIGHT);
+									drag_event = true;
+								} break;
+								case DisplayServer::WINDOW_DECORATION_BOTTOM_LEFT: {
+									_process_window_drag(window_id, event, _NET_WM_MOVERESIZE_SIZE_BOTTOMLEFT);
+									drag_event = true;
+								} break;
+								case DisplayServer::WINDOW_DECORATION_BOTTOM: {
+									_process_window_drag(window_id, event, _NET_WM_MOVERESIZE_SIZE_BOTTOM);
+									drag_event = true;
+								} break;
+								case DisplayServer::WINDOW_DECORATION_BOTTOM_RIGHT: {
+									_process_window_drag(window_id, event, _NET_WM_MOVERESIZE_SIZE_BOTTOMRIGHT);
+									drag_event = true;
+								} break;
+								case DisplayServer::WINDOW_DECORATION_MOVE: {
+									_process_window_drag(window_id, event, _NET_WM_MOVERESIZE_MOVE);
+									drag_event = true;
+								} break;
+								default:
+									break;
+							}
+						}
+					}
+
+					if (drag_event) {
+						break;
+					}
+				}
+				[[fallthrough]];
+			}
 			case ButtonRelease: {
 				if (ime_window_event || ignore_events) {
 					break;

--- a/platform/linuxbsd/x11/display_server_x11.cpp
+++ b/platform/linuxbsd/x11/display_server_x11.cpp
@@ -4793,7 +4793,7 @@ void DisplayServerX11::process_events() {
 								} break;
 								case DisplayServer::WINDOW_DECORATION_MOVE: {
 									_process_window_drag(window_id, event, _NET_WM_MOVERESIZE_MOVE);
-									drag_event = true;
+									// drag_event = true;
 								} break;
 								default:
 									break;
@@ -4865,6 +4865,25 @@ void DisplayServerX11::process_events() {
 						last_click_ms += diff;
 						last_click_pos = Point2i(event.xbutton.x, event.xbutton.y);
 					}
+
+					if (event.xbutton.button == 1 && mb->is_double_click()) {
+						for (const KeyValue<int, DisplayServerX11::DecorData> &E : windows[window_id].decor) {
+							if (Geometry2D::is_point_in_polygon(Vector2i(event.xbutton.x, event.xbutton.y), E.value.region)) {
+								switch (E.value.dec_type) {
+									case DisplayServer::WINDOW_DECORATION_MOVE: {
+										if (_window_maximize_check(window_id, "_NET_WM_STATE") == true) {
+											_set_wm_maximized(window_id, false);
+										} else {
+											_set_wm_maximized(window_id, true);
+										}
+									} break;
+									default:
+										break;
+								}
+							}
+						}
+					}
+
 				} else {
 					DEBUG_LOG_X11("[%u] ButtonRelease window=%lu (%u), button_index=%u \n", frame, event.xbutton.window, window_id, mb->get_button_index());
 

--- a/platform/linuxbsd/x11/display_server_x11.cpp
+++ b/platform/linuxbsd/x11/display_server_x11.cpp
@@ -4865,7 +4865,7 @@ void DisplayServerX11::process_events() {
 						last_click_ms += diff;
 						last_click_pos = Point2i(event.xbutton.x, event.xbutton.y);
 					}
-					// maximise window. remove it doesn't work
+
 					if (event.xbutton.button == 1 && mb->is_double_click()) {
 						for (const KeyValue<int, DisplayServerX11::DecorData> &E : windows[window_id].decor) {
 							if (Geometry2D::is_point_in_polygon(Vector2i(event.xbutton.x, event.xbutton.y), E.value.region)) {
@@ -4879,7 +4879,7 @@ void DisplayServerX11::process_events() {
 							}
 						}
 					}
-					//maximise window. remove if doesn't work
+
 				} else {
 					DEBUG_LOG_X11("[%u] ButtonRelease window=%lu (%u), button_index=%u \n", frame, event.xbutton.window, window_id, mb->get_button_index());
 

--- a/platform/linuxbsd/x11/display_server_x11.cpp
+++ b/platform/linuxbsd/x11/display_server_x11.cpp
@@ -2528,7 +2528,7 @@ bool DisplayServerX11::window_is_maximize_allowed(WindowID p_window) const {
 	return _window_maximize_check(p_window, "_NET_WM_ALLOWED_ACTIONS");
 }
 
-void DisplayServerX11::_set_wm_maximized(WindowID p_window, bool p_enabled) {
+void DisplayServerX11::__maximized(WindowID p_window, bool p_enabled) {
 	ERR_FAIL_COND(!windows.has(p_window));
 	WindowData &wd = windows[p_window];
 
@@ -2560,7 +2560,7 @@ void DisplayServerX11::_set_wm_maximized(WindowID p_window, bool p_enabled) {
 	wd.maximized = p_enabled;
 }
 
-void DisplayServerX11::_set_wm_minimized(WindowID p_window, bool p_enabled) {
+void DisplayServerX11::__minimized(WindowID p_window, bool p_enabled) {
 	WindowData &wd = windows[p_window];
 	// Using ICCCM -- Inter-Client Communication Conventions Manual
 	XEvent xev;
@@ -2590,7 +2590,7 @@ void DisplayServerX11::_set_wm_minimized(WindowID p_window, bool p_enabled) {
 	wd.minimized = p_enabled;
 }
 
-void DisplayServerX11::_set_wm_fullscreen(WindowID p_window, bool p_enabled, bool p_exclusive) {
+void DisplayServerX11::__fullscreen(WindowID p_window, bool p_enabled, bool p_exclusive) {
 	ERR_FAIL_COND(!windows.has(p_window));
 	WindowData &wd = windows[p_window];
 
@@ -2676,7 +2676,7 @@ void DisplayServerX11::window_set_mode(WindowMode p_mode, WindowID p_window) {
 			//do nothing
 		} break;
 		case WINDOW_MODE_MINIMIZED: {
-			_set_wm_minimized(p_window, false);
+			__minimized(p_window, false);
 		} break;
 		case WINDOW_MODE_EXCLUSIVE_FULLSCREEN:
 		case WINDOW_MODE_FULLSCREEN: {
@@ -2684,7 +2684,7 @@ void DisplayServerX11::window_set_mode(WindowMode p_mode, WindowID p_window) {
 			wd.fullscreen = false;
 			wd.exclusive_fullscreen = false;
 
-			_set_wm_fullscreen(p_window, false, false);
+			__fullscreen(p_window, false, false);
 
 			//un-maximize required for always on top
 			bool on_top = window_get_flag(WINDOW_FLAG_ALWAYS_ON_TOP, p_window);
@@ -2692,12 +2692,12 @@ void DisplayServerX11::window_set_mode(WindowMode p_mode, WindowID p_window) {
 			window_set_position(wd.last_position_before_fs, p_window);
 
 			if (on_top) {
-				_set_wm_maximized(p_window, false);
+				__maximized(p_window, false);
 			}
 
 		} break;
 		case WINDOW_MODE_MAXIMIZED: {
-			_set_wm_maximized(p_window, false);
+			__maximized(p_window, false);
 		} break;
 	}
 
@@ -2706,27 +2706,27 @@ void DisplayServerX11::window_set_mode(WindowMode p_mode, WindowID p_window) {
 			//do nothing
 		} break;
 		case WINDOW_MODE_MINIMIZED: {
-			_set_wm_minimized(p_window, true);
+			__minimized(p_window, true);
 		} break;
 		case WINDOW_MODE_EXCLUSIVE_FULLSCREEN:
 		case WINDOW_MODE_FULLSCREEN: {
 			wd.last_position_before_fs = wd.position;
 
 			if (window_get_flag(WINDOW_FLAG_ALWAYS_ON_TOP, p_window)) {
-				_set_wm_maximized(p_window, true);
+				__maximized(p_window, true);
 			}
 
 			wd.fullscreen = true;
 			if (p_mode == WINDOW_MODE_EXCLUSIVE_FULLSCREEN) {
 				wd.exclusive_fullscreen = true;
-				_set_wm_fullscreen(p_window, true, true);
+				__fullscreen(p_window, true, true);
 			} else {
 				wd.exclusive_fullscreen = false;
-				_set_wm_fullscreen(p_window, true, false);
+				__fullscreen(p_window, true, false);
 			}
 		} break;
 		case WINDOW_MODE_MAXIMIZED: {
-			_set_wm_maximized(p_window, true);
+			__maximized(p_window, true);
 		} break;
 	}
 }
@@ -2795,7 +2795,7 @@ void DisplayServerX11::window_set_flag(WindowFlags p_flag, bool p_enabled, Windo
 		case WINDOW_FLAG_ALWAYS_ON_TOP: {
 			ERR_FAIL_COND_MSG(wd.transient_parent != INVALID_WINDOW_ID, "Can't make a window transient if the 'on top' flag is active.");
 			if (p_enabled && wd.fullscreen) {
-				_set_wm_maximized(p_window, true);
+				__maximized(p_window, true);
 			}
 
 			Atom wm_state = XInternAtom(x11_display, "_NET_WM_STATE", False);
@@ -2813,7 +2813,7 @@ void DisplayServerX11::window_set_flag(WindowFlags p_flag, bool p_enabled, Windo
 			XSendEvent(x11_display, DefaultRootWindow(x11_display), False, SubstructureRedirectMask | SubstructureNotifyMask, (XEvent *)&xev);
 
 			if (!p_enabled && !wd.fullscreen) {
-				_set_wm_maximized(p_window, false);
+				__maximized(p_window, false);
 			}
 			wd.on_top = p_enabled;
 
@@ -4871,11 +4871,7 @@ void DisplayServerX11::process_events() {
 							if (Geometry2D::is_point_in_polygon(Vector2i(event.xbutton.x, event.xbutton.y), E.value.region)) {
 								switch (E.value.dec_type) {
 									case DisplayServer::WINDOW_DECORATION_MOVE: {
-										if (_window_maximize_check(window_id, "_NET_WM_STATE") == true) {
-											_set_wm_maximized(window_id, false);
-										} else {
-											_set_wm_maximized(window_id, true);
-										}
+										_set_wm_maximized(window_id, !_window_maximize_check(window_id, "_NET_WM_STATE"));
 									} break;
 									default:
 										break;

--- a/platform/linuxbsd/x11/display_server_x11.cpp
+++ b/platform/linuxbsd/x11/display_server_x11.cpp
@@ -42,6 +42,7 @@
 #include "core/string/ustring.h"
 #include "drivers/png/png_driver_common.h"
 #include "main/main.h"
+#include "scene/resources/atlas_texture.h"
 
 #if defined(VULKAN_ENABLED)
 #include "servers/rendering/renderer_rd/renderer_compositor_rd.h"
@@ -120,11 +121,6 @@ static String get_atom_name(Display *p_disp, Atom p_atom) {
 
 bool DisplayServerX11::has_feature(Feature p_feature) const {
 	switch (p_feature) {
-#ifndef DISABLE_DEPRECATED
-		case FEATURE_GLOBAL_MENU: {
-			return (native_menu && native_menu->has_feature(NativeMenu::FEATURE_GLOBAL_MENU));
-		} break;
-#endif
 		case FEATURE_SUBWINDOWS:
 #ifdef TOUCH_ENABLED
 		case FEATURE_TOUCHSCREEN:
@@ -139,10 +135,8 @@ bool DisplayServerX11::has_feature(Feature p_feature) const {
 		//case FEATURE_HIDPI:
 		case FEATURE_ICON:
 #ifdef DBUS_ENABLED
-		case FEATURE_NATIVE_DIALOG_FILE:
+		case FEATURE_NATIVE_DIALOG:
 #endif
-		//case FEATURE_NATIVE_DIALOG:
-		//case FEATURE_NATIVE_DIALOG_INPUT:
 		//case FEATURE_NATIVE_ICON:
 		case FEATURE_SWAP_BUFFERS:
 #ifdef DBUS_ENABLED
@@ -150,10 +144,9 @@ bool DisplayServerX11::has_feature(Feature p_feature) const {
 #endif
 		case FEATURE_CLIPBOARD_PRIMARY:
 		case FEATURE_TEXT_TO_SPEECH:
+		case FEATURE_SCREEN_CAPTURE:
 		case FEATURE_CLIENT_SIDE_DECORATIONS:
 			return true;
-		case FEATURE_SCREEN_CAPTURE:
-			return !xwayland;
 		default: {
 		}
 	}
@@ -383,10 +376,6 @@ bool DisplayServerX11::is_dark_mode() const {
 	}
 }
 
-void DisplayServerX11::set_system_theme_change_callback(const Callable &p_callable) {
-	portal_desktop->set_system_theme_change_callback(p_callable);
-}
-
 Error DisplayServerX11::file_dialog_show(const String &p_title, const String &p_current_directory, const String &p_filename, bool p_show_hidden, FileDialogMode p_mode, const Vector<String> &p_filters, const Callable &p_callback) {
 	WindowID window_id = last_focused_window;
 
@@ -395,18 +384,7 @@ Error DisplayServerX11::file_dialog_show(const String &p_title, const String &p_
 	}
 
 	String xid = vformat("x11:%x", (uint64_t)windows[window_id].x11_window);
-	return portal_desktop->file_dialog_show(last_focused_window, xid, p_title, p_current_directory, String(), p_filename, p_mode, p_filters, TypedArray<Dictionary>(), p_callback, false);
-}
-
-Error DisplayServerX11::file_dialog_with_options_show(const String &p_title, const String &p_current_directory, const String &p_root, const String &p_filename, bool p_show_hidden, FileDialogMode p_mode, const Vector<String> &p_filters, const TypedArray<Dictionary> &p_options, const Callable &p_callback) {
-	WindowID window_id = last_focused_window;
-
-	if (!windows.has(window_id)) {
-		window_id = MAIN_WINDOW_ID;
-	}
-
-	String xid = vformat("x11:%x", (uint64_t)windows[window_id].x11_window);
-	return portal_desktop->file_dialog_show(last_focused_window, xid, p_title, p_current_directory, p_root, p_filename, p_mode, p_filters, p_options, p_callback, true);
+	return portal_desktop->file_dialog_show(last_focused_window, xid, p_title, p_current_directory, p_filename, p_mode, p_filters, p_callback);
 }
 
 #endif
@@ -515,34 +493,7 @@ Point2i DisplayServerX11::mouse_get_position() const {
 }
 
 BitField<MouseButtonMask> DisplayServerX11::mouse_get_button_state() const {
-	int number_of_screens = XScreenCount(x11_display);
-	for (int i = 0; i < number_of_screens; i++) {
-		Window root, child;
-		int root_x, root_y, win_x, win_y;
-		unsigned int mask;
-		if (XQueryPointer(x11_display, XRootWindow(x11_display, i), &root, &child, &root_x, &root_y, &win_x, &win_y, &mask)) {
-			BitField<MouseButtonMask> last_button_state = 0;
-
-			if (mask & Button1Mask) {
-				last_button_state.set_flag(MouseButtonMask::LEFT);
-			}
-			if (mask & Button2Mask) {
-				last_button_state.set_flag(MouseButtonMask::MIDDLE);
-			}
-			if (mask & Button3Mask) {
-				last_button_state.set_flag(MouseButtonMask::RIGHT);
-			}
-			if (mask & Button4Mask) {
-				last_button_state.set_flag(MouseButtonMask::MB_XBUTTON1);
-			}
-			if (mask & Button5Mask) {
-				last_button_state.set_flag(MouseButtonMask::MB_XBUTTON2);
-			}
-
-			return last_button_state;
-		}
-	}
-	return 0;
+	return last_button_state;
 }
 
 void DisplayServerX11::clipboard_set(const String &p_text) {
@@ -1047,8 +998,7 @@ int DisplayServerX11::get_screen_count() const {
 	if (xinerama_ext_ok && XineramaQueryExtension(x11_display, &event_base, &error_base)) {
 		XineramaScreenInfo *xsi = XineramaQueryScreens(x11_display, &count);
 		XFree(xsi);
-	}
-	if (count == 0) {
+	} else {
 		count = XScreenCount(x11_display);
 	}
 
@@ -1109,29 +1059,25 @@ Rect2i DisplayServerX11::_screen_get_rect(int p_screen) const {
 	ERR_FAIL_COND_V(p_screen < 0, rect);
 
 	// Using Xinerama Extension.
-	bool found = false;
 	int event_base, error_base;
 	if (xinerama_ext_ok && XineramaQueryExtension(x11_display, &event_base, &error_base)) {
 		int count;
 		XineramaScreenInfo *xsi = XineramaQueryScreens(x11_display, &count);
+
+		// Check if screen is valid.
+		if (p_screen < count) {
+			rect.position.x = xsi[p_screen].x_org;
+			rect.position.y = xsi[p_screen].y_org;
+			rect.size.width = xsi[p_screen].width;
+			rect.size.height = xsi[p_screen].height;
+		} else {
+			ERR_PRINT("Invalid screen index: " + itos(p_screen) + "(count: " + itos(count) + ").");
+		}
+
 		if (xsi) {
-			if (count > 0) {
-				// Check if screen is valid.
-				if (p_screen < count) {
-					rect.position.x = xsi[p_screen].x_org;
-					rect.position.y = xsi[p_screen].y_org;
-					rect.size.width = xsi[p_screen].width;
-					rect.size.height = xsi[p_screen].height;
-					found = true;
-				} else {
-					ERR_PRINT(vformat("Invalid screen index: %d (count: %d).", p_screen, count));
-				}
-			}
 			XFree(xsi);
 		}
-	}
-
-	if (!found) {
+	} else {
 		int count = XScreenCount(x11_display);
 		if (p_screen < count) {
 			Window root = XRootWindow(x11_display, p_screen);
@@ -1142,7 +1088,7 @@ Rect2i DisplayServerX11::_screen_get_rect(int p_screen) const {
 			rect.size.width = xwa.width;
 			rect.size.height = xwa.height;
 		} else {
-			ERR_PRINT(vformat("Invalid screen index: %d (count: %d).", p_screen, count));
+			ERR_PRINT("Invalid screen index: " + itos(p_screen) + "(count: " + itos(count) + ").");
 		}
 	}
 
@@ -1507,20 +1453,9 @@ int DisplayServerX11::screen_get_dpi(int p_screen) const {
 	return 96;
 }
 
-int get_image_errorhandler(Display *dpy, XErrorEvent *ev) {
-	return 0;
-}
-
 Color DisplayServerX11::screen_get_pixel(const Point2i &p_position) const {
 	Point2i pos = p_position;
 
-	if (xwayland) {
-		return Color();
-	}
-
-	int (*old_handler)(Display *, XErrorEvent *) = XSetErrorHandler(&get_image_errorhandler);
-
-	Color color;
 	int number_of_screens = XScreenCount(x11_display);
 	for (int i = 0; i < number_of_screens; i++) {
 		Window root = XRootWindow(x11_display, i);
@@ -1531,17 +1466,14 @@ Color DisplayServerX11::screen_get_pixel(const Point2i &p_position) const {
 			if (image) {
 				XColor c;
 				c.pixel = XGetPixel(image, 0, 0);
-				XDestroyImage(image);
+				XFree(image);
 				XQueryColor(x11_display, XDefaultColormap(x11_display, i), &c);
-				color = Color(float(c.red) / 65535.0, float(c.green) / 65535.0, float(c.blue) / 65535.0, 1.0);
-				break;
+				return Color(float(c.red) / 65535.0, float(c.green) / 65535.0, float(c.blue) / 65535.0, 1.0);
 			}
 		}
 	}
 
-	XSetErrorHandler(old_handler);
-
-	return color;
+	return Color();
 }
 
 Ref<Image> DisplayServerX11::screen_get_image(int p_screen) const {
@@ -1560,41 +1492,27 @@ Ref<Image> DisplayServerX11::screen_get_image(int p_screen) const {
 
 	ERR_FAIL_COND_V(p_screen < 0, Ref<Image>());
 
-	if (xwayland) {
-		return Ref<Image>();
-	}
-
-	int (*old_handler)(Display *, XErrorEvent *) = XSetErrorHandler(&get_image_errorhandler);
-
 	XImage *image = nullptr;
 
-	bool found = false;
 	int event_base, error_base;
 	if (xinerama_ext_ok && XineramaQueryExtension(x11_display, &event_base, &error_base)) {
 		int xin_count;
 		XineramaScreenInfo *xsi = XineramaQueryScreens(x11_display, &xin_count);
-		if (xsi) {
-			if (xin_count > 0) {
-				if (p_screen < xin_count) {
-					int x_count = XScreenCount(x11_display);
-					for (int i = 0; i < x_count; i++) {
-						Window root = XRootWindow(x11_display, i);
-						XWindowAttributes root_attrs;
-						XGetWindowAttributes(x11_display, root, &root_attrs);
-						if ((xsi[p_screen].x_org >= root_attrs.x) && (xsi[p_screen].x_org <= root_attrs.x + root_attrs.width) && (xsi[p_screen].y_org >= root_attrs.y) && (xsi[p_screen].y_org <= root_attrs.y + root_attrs.height)) {
-							found = true;
-							image = XGetImage(x11_display, root, xsi[p_screen].x_org, xsi[p_screen].y_org, xsi[p_screen].width, xsi[p_screen].height, AllPlanes, ZPixmap);
-							break;
-						}
-					}
-				} else {
-					ERR_PRINT(vformat("Invalid screen index: %d (count: %d).", p_screen, xin_count));
+		if (p_screen < xin_count) {
+			int x_count = XScreenCount(x11_display);
+			for (int i = 0; i < x_count; i++) {
+				Window root = XRootWindow(x11_display, i);
+				XWindowAttributes root_attrs;
+				XGetWindowAttributes(x11_display, root, &root_attrs);
+				if ((xsi[p_screen].x_org >= root_attrs.x) && (xsi[p_screen].x_org <= root_attrs.x + root_attrs.width) && (xsi[p_screen].y_org >= root_attrs.y) && (xsi[p_screen].y_org <= root_attrs.y + root_attrs.height)) {
+					image = XGetImage(x11_display, root, xsi[p_screen].x_org, xsi[p_screen].y_org, xsi[p_screen].width, xsi[p_screen].height, AllPlanes, ZPixmap);
+					break;
 				}
 			}
-			XFree(xsi);
+		} else {
+			ERR_FAIL_V_MSG(Ref<Image>(), "Invalid screen index: " + itos(p_screen) + "(count: " + itos(xin_count) + ").");
 		}
-	}
-	if (!found) {
+	} else {
 		int x_count = XScreenCount(x11_display);
 		if (p_screen < x_count) {
 			Window root = XRootWindow(x11_display, p_screen);
@@ -1604,11 +1522,9 @@ Ref<Image> DisplayServerX11::screen_get_image(int p_screen) const {
 
 			image = XGetImage(x11_display, root, root_attrs.x, root_attrs.y, root_attrs.width, root_attrs.height, AllPlanes, ZPixmap);
 		} else {
-			ERR_PRINT(vformat("Invalid screen index: %d (count: %d).", p_screen, x_count));
+			ERR_FAIL_V_MSG(Ref<Image>(), "Invalid screen index: " + itos(p_screen) + "(count: " + itos(x_count) + ").");
 		}
 	}
-
-	XSetErrorHandler(old_handler);
 
 	Ref<Image> img;
 	if (image) {
@@ -1649,12 +1565,11 @@ Ref<Image> DisplayServerX11::screen_get_image(int p_screen) const {
 				}
 			}
 		} else {
-			String msg = vformat("XImage with RGB mask %x %x %x and depth %d is not supported.", (uint64_t)image->red_mask, (uint64_t)image->green_mask, (uint64_t)image->blue_mask, (int64_t)image->bits_per_pixel);
-			XDestroyImage(image);
-			ERR_FAIL_V_MSG(Ref<Image>(), msg);
+			XFree(image);
+			ERR_FAIL_V_MSG(Ref<Image>(), vformat("XImage with RGB mask %x %x %x and depth %d is not supported.", (uint64_t)image->red_mask, (uint64_t)image->green_mask, (uint64_t)image->blue_mask, (int64_t)image->bits_per_pixel));
 		}
 		img = Image::create_from_data(width, height, false, Image::FORMAT_RGBA8, img_data);
-		XDestroyImage(image);
+		XFree(image);
 	}
 
 	return img;
@@ -1747,7 +1662,7 @@ Vector<DisplayServer::WindowID> DisplayServerX11::get_window_list() const {
 	return ret;
 }
 
-DisplayServer::WindowID DisplayServerX11::create_sub_window(WindowMode p_mode, VSyncMode p_vsync_mode, uint32_t p_flags, const Rect2i &p_rect, bool p_exclusive, WindowID p_transient_parent) {
+DisplayServer::WindowID DisplayServerX11::create_sub_window(WindowMode p_mode, VSyncMode p_vsync_mode, uint32_t p_flags, const Rect2i &p_rect) {
 	_THREAD_SAFE_METHOD_
 
 	WindowID id = _create_window(p_mode, p_vsync_mode, p_flags, p_rect);
@@ -1755,15 +1670,6 @@ DisplayServer::WindowID DisplayServerX11::create_sub_window(WindowMode p_mode, V
 		if (p_flags & (1 << i)) {
 			window_set_flag(WindowFlags(i), true, id);
 		}
-	}
-#ifdef RD_ENABLED
-	if (rendering_device) {
-		rendering_device->screen_create(id);
-	}
-#endif
-
-	if (p_transient_parent != INVALID_WINDOW_ID) {
-		window_set_transient(id, p_transient_parent);
 	}
 
 	return id;
@@ -1813,13 +1719,9 @@ void DisplayServerX11::delete_sub_window(WindowID p_id) {
 		window_set_transient(p_id, INVALID_WINDOW_ID);
 	}
 
-#if defined(RD_ENABLED)
-	if (rendering_device) {
-		rendering_device->screen_free(p_id);
-	}
-
-	if (rendering_context) {
-		rendering_context->window_destroy(p_id);
+#ifdef VULKAN_ENABLED
+	if (context_vulkan) {
+		context_vulkan->window_destroy(p_id);
 	}
 #endif
 #ifdef GLES3_ENABLED
@@ -2116,7 +2018,8 @@ void DisplayServerX11::window_set_current_screen(int p_screen, WindowID p_window
 		Size2i wsize = window_get_size(p_window);
 		wpos += srect.position;
 		if (srect != Rect2i()) {
-			wpos = wpos.clamp(srect.position, srect.position + srect.size - wsize / 3);
+			wpos.x = CLAMP(wpos.x, srect.position.x, srect.position.x + srect.size.width - wsize.width / 3);
+			wpos.y = CLAMP(wpos.y, srect.position.y, srect.position.y + srect.size.height - wsize.height / 3);
 		}
 		window_set_position(wpos, p_window);
 	}
@@ -2157,8 +2060,8 @@ void DisplayServerX11::window_set_transient(WindowID p_window, WindowID p_parent
 		// RevertToPointerRoot is used to make sure we don't lose all focus in case
 		// a subwindow and its parent are both destroyed.
 		if (!wd_window.no_focus && !wd_window.is_popup && wd_window.focused) {
-			if ((xwa.map_state == IsViewable) && !wd_parent.no_focus && !wd_window.is_popup && _window_focus_check()) {
-				_set_input_focus(wd_parent.x11_window, RevertToPointerRoot);
+			if ((xwa.map_state == IsViewable) && !wd_parent.no_focus && !wd_window.is_popup) {
+				XSetInputFocus(x11_display, wd_parent.x11_window, RevertToPointerRoot, CurrentTime);
 			}
 		}
 	} else {
@@ -2344,7 +2247,8 @@ void DisplayServerX11::window_set_size(const Size2i p_size, WindowID p_window) {
 	ERR_FAIL_COND(!windows.has(p_window));
 
 	Size2i size = p_size;
-	size = size.maxi(1);
+	size.x = MAX(1, size.x);
+	size.y = MAX(1, size.y);
 
 	WindowData &wd = windows[p_window];
 
@@ -2375,13 +2279,13 @@ void DisplayServerX11::window_set_size(const Size2i p_size, WindowID p_window) {
 			break;
 		}
 
-		OS::get_singleton()->delay_usec(10'000);
+		usleep(10000);
 	}
 
 	// Keep rendering context window size in sync
-#if defined(RD_ENABLED)
-	if (rendering_context) {
-		rendering_context->window_set_size(p_window, xwa.width, xwa.height);
+#if defined(VULKAN_ENABLED)
+	if (context_vulkan) {
+		context_vulkan->window_resize(p_window, xwa.width, xwa.height);
 	}
 #endif
 #if defined(GLES3_ENABLED)
@@ -2650,7 +2554,7 @@ void DisplayServerX11::_set_wm_maximized(WindowID p_window, bool p_enabled) {
 		// Give up after 0.5s, it's not going to happen on this WM.
 		// https://github.com/godotengine/godot/issues/19978
 		for (int attempt = 0; window_get_mode(p_window) != WINDOW_MODE_MAXIMIZED && attempt < 50; attempt++) {
-			OS::get_singleton()->delay_usec(10'000);
+			usleep(10000);
 		}
 	}
 	wd.maximized = p_enabled;
@@ -3037,15 +2941,10 @@ void DisplayServerX11::window_move_to_foreground(WindowID p_window) {
 	XFlush(x11_display);
 }
 
-DisplayServerX11::WindowID DisplayServerX11::get_focused_window() const {
-	return last_focused_window;
-}
-
 bool DisplayServerX11::window_is_focused(WindowID p_window) const {
 	_THREAD_SAFE_METHOD_
 
 	ERR_FAIL_COND_V(!windows.has(p_window), false);
-
 	const WindowData &wd = windows[p_window];
 
 	return wd.focused;
@@ -3097,7 +2996,7 @@ void DisplayServerX11::window_set_ime_active(const bool p_active, WindowID p_win
 		XSync(x11_display, False);
 		XGetWindowAttributes(x11_display, wd.x11_xim_window, &xwa);
 		if (xwa.map_state == IsViewable) {
-			_set_input_focus(wd.x11_xim_window, RevertToParent);
+			XSetInputFocus(x11_display, wd.x11_xim_window, RevertToParent, CurrentTime);
 		}
 		XSetICFocus(wd.xic);
 	} else {
@@ -3187,9 +3086,39 @@ void DisplayServerX11::cursor_set_custom_image(const Ref<Resource> &p_cursor, Cu
 			cursors_cache.erase(p_shape);
 		}
 
-		Ref<Image> image = _get_cursor_image_from_resource(p_cursor, p_hotspot);
-		ERR_FAIL_COND(image.is_null());
-		Vector2i texture_size = image->get_size();
+		Ref<Texture2D> texture = p_cursor;
+		ERR_FAIL_COND(!texture.is_valid());
+		Ref<AtlasTexture> atlas_texture = p_cursor;
+		Size2i texture_size;
+		Rect2i atlas_rect;
+
+		if (atlas_texture.is_valid()) {
+			texture = atlas_texture->get_atlas();
+
+			atlas_rect.size.width = texture->get_width();
+			atlas_rect.size.height = texture->get_height();
+			atlas_rect.position.x = atlas_texture->get_region().position.x;
+			atlas_rect.position.y = atlas_texture->get_region().position.y;
+
+			texture_size.width = atlas_texture->get_region().size.x;
+			texture_size.height = atlas_texture->get_region().size.y;
+		} else {
+			texture_size.width = texture->get_width();
+			texture_size.height = texture->get_height();
+		}
+
+		ERR_FAIL_COND(p_hotspot.x < 0 || p_hotspot.y < 0);
+		ERR_FAIL_COND(texture_size.width > 256 || texture_size.height > 256);
+		ERR_FAIL_COND(p_hotspot.x > texture_size.width || p_hotspot.y > texture_size.height);
+
+		Ref<Image> image = texture->get_image();
+
+		ERR_FAIL_COND(!image.is_valid());
+		if (image->is_compressed()) {
+			image = image->duplicate(true);
+			Error err = image->decompress();
+			ERR_FAIL_COND_MSG(err != OK, "Couldn't decompress VRAM-compressed custom mouse cursor image. Switch to a lossless compression mode in the Import dock.");
+		}
 
 		// Create the cursor structure
 		XcursorImage *cursor_image = XcursorImageCreate(texture_size.width, texture_size.height);
@@ -3205,8 +3134,13 @@ void DisplayServerX11::cursor_set_custom_image(const Ref<Resource> &p_cursor, Cu
 		cursor_image->pixels = (XcursorPixel *)memalloc(size);
 
 		for (XcursorPixel index = 0; index < image_size; index++) {
-			int row_index = floor(index / texture_size.width);
-			int column_index = index % int(texture_size.width);
+			int row_index = floor(index / texture_size.width) + atlas_rect.position.y;
+			int column_index = (index % int(texture_size.width)) + atlas_rect.position.x;
+
+			if (atlas_texture.is_valid()) {
+				column_index = MIN(column_index, atlas_rect.size.width - 1);
+				row_index = MIN(row_index, atlas_rect.size.height - 1);
+			}
 
 			*(cursor_image->pixels + index) = image->get_pixel(column_index, row_index).to_argb32();
 		}
@@ -3451,6 +3385,18 @@ void DisplayServerX11::_get_key_modifier_state(unsigned int p_x11_state, Ref<Inp
 	state->set_meta_pressed((p_x11_state & Mod4Mask));
 }
 
+BitField<MouseButtonMask> DisplayServerX11::_get_mouse_button_state(MouseButton p_x11_button, int p_x11_type) {
+	MouseButtonMask mask = mouse_button_to_mask(p_x11_button);
+
+	if (p_x11_type == ButtonPress) {
+		last_button_state.set_flag(mask);
+	} else {
+		last_button_state.clear_flag(mask);
+	}
+
+	return last_button_state;
+}
+
 void DisplayServerX11::_handle_key_event(WindowID p_window, XKeyEvent *p_event, LocalVector<XEvent> &p_events, uint32_t &p_event_index, bool p_echo) {
 	WindowData &wd = windows[p_window];
 	// X11 functions don't know what const is
@@ -3600,7 +3546,6 @@ void DisplayServerX11::_handle_key_event(WindowID p_window, XKeyEvent *p_event, 
 				bool keypress = xkeyevent->type == KeyPress;
 				Key keycode = KeyMappingX11::get_keycode(keysym_keycode);
 				Key physical_keycode = KeyMappingX11::get_scancode(xkeyevent->keycode);
-				KeyLocation key_location = KeyMappingX11::get_location(xkeyevent->keycode);
 
 				if (keycode >= Key::A + 32 && keycode <= Key::Z + 32) {
 					keycode -= 'a' - 'A';
@@ -3638,8 +3583,6 @@ void DisplayServerX11::_handle_key_event(WindowID p_window, XKeyEvent *p_event, 
 						k->set_unicode(fix_unicode(tmp[i]));
 					}
 
-					k->set_location(key_location);
-
 					k->set_echo(false);
 
 					if (k->get_keycode() == Key::BACKTAB) {
@@ -3664,8 +3607,6 @@ void DisplayServerX11::_handle_key_event(WindowID p_window, XKeyEvent *p_event, 
 
 	Key keycode = KeyMappingX11::get_keycode(keysym_keycode);
 	Key physical_keycode = KeyMappingX11::get_scancode(xkeyevent->keycode);
-
-	KeyLocation key_location = KeyMappingX11::get_location(xkeyevent->keycode);
 
 	/* Phase 3, obtain a unicode character from the keysym */
 
@@ -3766,9 +3707,6 @@ void DisplayServerX11::_handle_key_event(WindowID p_window, XKeyEvent *p_event, 
 	if (keypress) {
 		k->set_unicode(fix_unicode(unicode));
 	}
-
-	k->set_location(key_location);
-
 	k->set_echo(p_echo);
 
 	if (k->get_keycode() == Key::BACKTAB) {
@@ -3987,7 +3925,7 @@ void DisplayServerX11::_xim_preedit_draw_callback(::XIM xim, ::XPointer client_d
 			ds->im_selection = Point2i();
 		}
 
-		callable_mp((Object *)OS_Unix::get_singleton()->get_main_loop(), &Object::notification).call_deferred(MainLoop::NOTIFICATION_OS_IME_UPDATE, false);
+		OS_Unix::get_singleton()->get_main_loop()->notification(MainLoop::NOTIFICATION_OS_IME_UPDATE);
 	}
 }
 
@@ -4057,9 +3995,9 @@ void DisplayServerX11::_window_changed(XEvent *event) {
 	wd.position = new_rect.position;
 	wd.size = new_rect.size;
 
-#if defined(RD_ENABLED)
-	if (rendering_context) {
-		rendering_context->window_set_size(window_id, wd.size.width, wd.size.height);
+#if defined(VULKAN_ENABLED)
+	if (context_vulkan) {
+		context_vulkan->window_resize(window_id, wd.size.width, wd.size.height);
 	}
 #endif
 #if defined(GLES3_ENABLED)
@@ -4128,18 +4066,6 @@ void DisplayServerX11::_send_window_event(const WindowData &wd, WindowEvent p_ev
 	if (wd.event_callback.is_valid()) {
 		Variant event = int(p_event);
 		wd.event_callback.call(event);
-	}
-}
-
-void DisplayServerX11::_set_input_focus(Window p_window, int p_revert_to) {
-	Window focused_window;
-	int focus_ret_state;
-	XGetInputFocus(x11_display, &focused_window, &focus_ret_state);
-
-	// Only attempt to change focus if the window isn't already focused, in order to
-	// prevent issues with Godot stealing input focus with alternative window managers.
-	if (p_window != focused_window) {
-		XSetInputFocus(x11_display, p_window, p_revert_to, CurrentTime);
 	}
 }
 
@@ -4263,11 +4189,8 @@ void DisplayServerX11::popup_open(WindowID p_window) {
 		}
 	}
 
-	// Detect tooltips and other similar popups that shouldn't block input to their parent.
-	bool ignores_input = window_get_flag(WINDOW_FLAG_NO_FOCUS, p_window) && window_get_flag(WINDOW_FLAG_MOUSE_PASSTHROUGH, p_window);
-
 	WindowData &wd = windows[p_window];
-	if (wd.is_popup || (has_popup_ancestor && !ignores_input)) {
+	if (wd.is_popup || has_popup_ancestor) {
 		// Find current popup parent, or root popup if new window is not transient.
 		List<WindowID>::Element *C = nullptr;
 		List<WindowID>::Element *E = popup_list.back();
@@ -4297,10 +4220,7 @@ void DisplayServerX11::popup_close(WindowID p_window) {
 		WindowID win_id = E->get();
 		popup_list.erase(E);
 
-		if (win_id != p_window) {
-			// Only request close on related windows, not this window.  We are already processing it.
-			_send_window_event(windows[win_id], DisplayServerX11::WINDOW_EVENT_CLOSE_REQUEST);
-		}
+		_send_window_event(windows[win_id], DisplayServerX11::WINDOW_EVENT_CLOSE_REQUEST);
 		E = F;
 	}
 }
@@ -4358,22 +4278,6 @@ bool DisplayServerX11::mouse_process_popups() {
 	return closed;
 }
 
-bool DisplayServerX11::_window_focus_check() {
-	Window focused_window;
-	int focus_ret_state;
-	XGetInputFocus(x11_display, &focused_window, &focus_ret_state);
-
-	bool has_focus = false;
-	for (const KeyValue<int, DisplayServerX11::WindowData> &wid : windows) {
-		if (wid.value.x11_window == focused_window) {
-			has_focus = true;
-			break;
-		}
-	}
-
-	return has_focus;
-}
-
 void DisplayServerX11::_process_window_drag(WindowID p_window, XEvent p_event, int p_dec_type) {
 	XClientMessageEvent m;
 	memset(&m, 0, sizeof(m));
@@ -4396,9 +4300,7 @@ void DisplayServerX11::_process_window_drag(WindowID p_window, XEvent p_event, i
 }
 
 void DisplayServerX11::process_events() {
-	ERR_FAIL_COND(!Thread::is_main_thread());
-
-	_THREAD_SAFE_LOCK_
+	_THREAD_SAFE_METHOD_
 
 #ifdef DISPLAY_SERVER_X11_DEBUG_LOGS_ENABLED
 	static int frame = 0;
@@ -4641,7 +4543,6 @@ void DisplayServerX11::process_events() {
 							sd->set_index(index);
 							sd->set_position(pos);
 							sd->set_relative(pos - curr_pos_elem->value);
-							sd->set_relative_screen_position(sd->get_relative());
 							Input::get_singleton()->parse_input_event(sd);
 
 							curr_pos_elem->value = pos;
@@ -4669,8 +4570,8 @@ void DisplayServerX11::process_events() {
 				// Set focus when menu window is started.
 				// RevertToPointerRoot is used to make sure we don't lose all focus in case
 				// a subwindow and its parent are both destroyed.
-				if ((xwa.map_state == IsViewable) && !wd.no_focus && !wd.is_popup && _window_focus_check()) {
-					_set_input_focus(wd.x11_window, RevertToPointerRoot);
+				if ((xwa.map_state == IsViewable) && !wd.no_focus && !wd.is_popup) {
+					XSetInputFocus(x11_display, wd.x11_window, RevertToPointerRoot, CurrentTime);
 				}
 
 				// Have we failed to set fullscreen while the window was unmapped?
@@ -4836,8 +4737,22 @@ void DisplayServerX11::process_events() {
 					break;
 				}
 
+				const WindowData &wd = windows[window_id];
+
+				XWindowAttributes xwa;
+				XSync(x11_display, False);
+				XGetWindowAttributes(x11_display, wd.x11_window, &xwa);
+
+				// Set focus when menu window is re-used.
+				// RevertToPointerRoot is used to make sure we don't lose all focus in case
+				// a subwindow and its parent are both destroyed.
+				if ((xwa.map_state == IsViewable) && !wd.no_focus && !wd.is_popup) {
+					XSetInputFocus(x11_display, wd.x11_window, RevertToPointerRoot, CurrentTime);
+				}
+
 				_window_changed(&event);
 			} break;
+
 			case ButtonPress: {
 				if (event.xbutton.button == 1) {
 					bool drag_event = false;
@@ -4985,19 +4900,11 @@ void DisplayServerX11::process_events() {
 				} else if (mb->get_button_index() == MouseButton::MIDDLE) {
 					mb->set_button_index(MouseButton::RIGHT);
 				}
+				mb->set_button_mask(_get_mouse_button_state(mb->get_button_index(), event.xbutton.type));
 				mb->set_position(Vector2(event.xbutton.x, event.xbutton.y));
 				mb->set_global_position(mb->get_position());
 
 				mb->set_pressed((event.type == ButtonPress));
-
-				if (mb->is_pressed() && mb->get_button_index() >= MouseButton::WHEEL_UP && mb->get_button_index() <= MouseButton::WHEEL_RIGHT) {
-					MouseButtonMask mask = mouse_button_to_mask(mb->get_button_index());
-					BitField<MouseButtonMask> scroll_mask = mouse_get_button_state();
-					scroll_mask.set_flag(mask);
-					mb->set_button_mask(scroll_mask);
-				} else {
-					mb->set_button_mask(mouse_get_button_state());
-				}
 
 				const WindowData &wd = windows[window_id];
 
@@ -5008,7 +4915,7 @@ void DisplayServerX11::process_events() {
 					// RevertToPointerRoot is used to make sure we don't lose all focus in case
 					// a subwindow and its parent are both destroyed.
 					if (!wd.no_focus && !wd.is_popup) {
-						_set_input_focus(wd.x11_window, RevertToPointerRoot);
+						XSetInputFocus(x11_display, wd.x11_window, RevertToPointerRoot, CurrentTime);
 					}
 
 					uint64_t diff = OS::get_singleton()->get_ticks_usec() / 1000 - last_click_ms;
@@ -5029,7 +4936,6 @@ void DisplayServerX11::process_events() {
 						last_click_ms += diff;
 						last_click_pos = Point2i(event.xbutton.x, event.xbutton.y);
 					}
-
 				} else {
 					DEBUG_LOG_X11("[%u] ButtonRelease window=%lu (%u), button_index=%u \n", frame, event.xbutton.window, window_id, mb->get_button_index());
 
@@ -5165,23 +5071,6 @@ void DisplayServerX11::process_events() {
 					pos = Point2i(windows[focused_window_id].size.width / 2, windows[focused_window_id].size.height / 2);
 				}
 
-				BitField<MouseButtonMask> last_button_state = 0;
-				if (event.xmotion.state & Button1Mask) {
-					last_button_state.set_flag(MouseButtonMask::LEFT);
-				}
-				if (event.xmotion.state & Button2Mask) {
-					last_button_state.set_flag(MouseButtonMask::MIDDLE);
-				}
-				if (event.xmotion.state & Button3Mask) {
-					last_button_state.set_flag(MouseButtonMask::RIGHT);
-				}
-				if (event.xmotion.state & Button4Mask) {
-					last_button_state.set_flag(MouseButtonMask::MB_XBUTTON1);
-				}
-				if (event.xmotion.state & Button5Mask) {
-					last_button_state.set_flag(MouseButtonMask::MB_XBUTTON2);
-				}
-
 				Ref<InputEventMouseMotion> mm;
 				mm.instantiate();
 
@@ -5189,20 +5078,18 @@ void DisplayServerX11::process_events() {
 				if (xi.pressure_supported) {
 					mm->set_pressure(xi.pressure);
 				} else {
-					mm->set_pressure(bool(last_button_state.has_flag(MouseButtonMask::LEFT)) ? 1.0f : 0.0f);
+					mm->set_pressure(bool(mouse_get_button_state().has_flag(MouseButtonMask::LEFT)) ? 1.0f : 0.0f);
 				}
 				mm->set_tilt(xi.tilt);
 				mm->set_pen_inverted(xi.pen_inverted);
 
 				_get_key_modifier_state(event.xmotion.state, mm);
-				mm->set_button_mask(last_button_state);
+				mm->set_button_mask(mouse_get_button_state());
 				mm->set_position(pos);
 				mm->set_global_position(pos);
 				mm->set_velocity(Input::get_singleton()->get_last_mouse_velocity());
-				mm->set_screen_velocity(mm->get_velocity());
 
 				mm->set_relative(rel);
-				mm->set_relative_screen_position(rel);
 
 				last_mouse_pos = pos;
 
@@ -5271,15 +5158,8 @@ void DisplayServerX11::process_events() {
 						files.write[i] = files[i].replace("file://", "").uri_decode();
 					}
 
-					if (windows[window_id].drop_files_callback.is_valid()) {
-						Variant v_files = files;
-						const Variant *v_args[1] = { &v_files };
-						Variant ret;
-						Callable::CallError ce;
-						windows[window_id].drop_files_callback.callp((const Variant **)&v_args, 1, ret, ce);
-						if (ce.error != Callable::CallError::CALL_OK) {
-							ERR_PRINT(vformat("Failed to execute drop files callback: %s.", Variant::get_callable_error_text(windows[window_id].drop_files_callback, v_args, 1, ce)));
-						}
+					if (!windows[window_id].drop_files_callback.is_null()) {
+						windows[window_id].drop_files_callback.call(files);
 					}
 
 					//Reply that all is well.
@@ -5383,14 +5263,6 @@ void DisplayServerX11::process_events() {
 		*/
 	}
 
-#ifdef DBUS_ENABLED
-	if (portal_desktop) {
-		portal_desktop->process_file_dialog_callbacks();
-	}
-#endif
-
-	_THREAD_SAFE_UNLOCK_
-
 	Input::get_singleton()->flush_buffered_events();
 }
 
@@ -5401,6 +5273,17 @@ void DisplayServerX11::release_rendering_thread() {
 	}
 	if (gl_manager_egl) {
 		gl_manager_egl->release_current();
+	}
+#endif
+}
+
+void DisplayServerX11::make_rendering_thread() {
+#if defined(GLES3_ENABLED)
+	if (gl_manager) {
+		gl_manager->make_current();
+	}
+	if (gl_manager_egl) {
+		gl_manager_egl->make_current();
 	}
 #endif
 }
@@ -5463,23 +5346,6 @@ void DisplayServerX11::set_context(Context p_context) {
 	}
 }
 
-bool DisplayServerX11::is_window_transparency_available() const {
-	CharString net_wm_cm_name = vformat("_NET_WM_CM_S%d", XDefaultScreen(x11_display)).ascii();
-	Atom net_wm_cm = XInternAtom(x11_display, net_wm_cm_name.get_data(), False);
-	if (net_wm_cm == None) {
-		return false;
-	}
-	if (XGetSelectionOwner(x11_display, net_wm_cm) == None) {
-		return false;
-	}
-#if defined(RD_ENABLED)
-	if (rendering_device && !rendering_device->is_composite_alpha_supported()) {
-		return false;
-	}
-#endif
-	return OS::get_singleton()->is_layered_allowed();
-}
-
 void DisplayServerX11::set_native_icon(const String &p_filename) {
 	WARN_PRINT("Native icon not supported by this display server.");
 }
@@ -5512,7 +5378,7 @@ void DisplayServerX11::set_icon(const Ref<Image> &p_icon) {
 			if (g_set_icon_error) {
 				g_set_icon_error = false;
 
-				WARN_PRINT(vformat("Icon too large (%dx%d), attempting to downscale icon.", w, h));
+				WARN_PRINT("Icon too large, attempting to resize icon.");
 
 				int new_width, new_height;
 				if (w > h) {
@@ -5573,9 +5439,9 @@ void DisplayServerX11::set_icon(const Ref<Image> &p_icon) {
 
 void DisplayServerX11::window_set_vsync_mode(DisplayServer::VSyncMode p_vsync_mode, WindowID p_window) {
 	_THREAD_SAFE_METHOD_
-#if defined(RD_ENABLED)
-	if (rendering_context) {
-		rendering_context->window_set_vsync_mode(p_window, p_vsync_mode);
+#if defined(VULKAN_ENABLED)
+	if (context_vulkan) {
+		context_vulkan->set_vsync_mode(p_window, p_vsync_mode);
 	}
 #endif
 
@@ -5591,9 +5457,9 @@ void DisplayServerX11::window_set_vsync_mode(DisplayServer::VSyncMode p_vsync_mo
 
 DisplayServer::VSyncMode DisplayServerX11::window_get_vsync_mode(WindowID p_window) const {
 	_THREAD_SAFE_METHOD_
-#if defined(RD_ENABLED)
-	if (rendering_context) {
-		return rendering_context->window_get_vsync_mode(p_window);
+#if defined(VULKAN_ENABLED)
+	if (context_vulkan) {
+		return context_vulkan->get_vsync_mode(p_window);
 	}
 #endif
 #if defined(GLES3_ENABLED)
@@ -5621,8 +5487,8 @@ Vector<String> DisplayServerX11::get_rendering_drivers_func() {
 	return drivers;
 }
 
-DisplayServer *DisplayServerX11::create_func(const String &p_rendering_driver, WindowMode p_mode, VSyncMode p_vsync_mode, uint32_t p_flags, const Vector2i *p_position, const Vector2i &p_resolution, int p_screen, Context p_context, Error &r_error) {
-	DisplayServer *ds = memnew(DisplayServerX11(p_rendering_driver, p_mode, p_vsync_mode, p_flags, p_position, p_resolution, p_screen, p_context, r_error));
+DisplayServer *DisplayServerX11::create_func(const String &p_rendering_driver, WindowMode p_mode, VSyncMode p_vsync_mode, uint32_t p_flags, const Vector2i *p_position, const Vector2i &p_resolution, int p_screen, Error &r_error) {
+	DisplayServer *ds = memnew(DisplayServerX11(p_rendering_driver, p_mode, p_vsync_mode, p_flags, p_position, p_resolution, p_screen, r_error));
 	if (r_error != OK) {
 		if (p_rendering_driver == "vulkan") {
 			String executable_name = OS::get_singleton()->get_executable_path().get_file();
@@ -5751,7 +5617,8 @@ DisplayServerX11::WindowID DisplayServerX11::_create_window(WindowMode p_mode, V
 	} else {
 		Rect2i srect = screen_get_usable_rect(rq_screen);
 		Point2i wpos = p_rect.position;
-		wpos = wpos.clamp(srect.position, srect.position + srect.size - p_rect.size / 3);
+		wpos.x = CLAMP(wpos.x, srect.position.x, srect.position.x + srect.size.width - p_rect.size.width / 3);
+		wpos.y = CLAMP(wpos.y, srect.position.y, srect.position.y + srect.size.height - p_rect.size.height / 3);
 
 		win_rect.position = wpos;
 	}
@@ -5934,24 +5801,10 @@ DisplayServerX11::WindowID DisplayServerX11::_create_window(WindowMode p_mode, V
 
 		_update_size_hints(id);
 
-#if defined(RD_ENABLED)
-		if (rendering_context) {
-			union {
-#ifdef VULKAN_ENABLED
-				RenderingContextDriverVulkanX11::WindowPlatformData vulkan;
-#endif
-			} wpd;
-#ifdef VULKAN_ENABLED
-			if (rendering_driver == "vulkan") {
-				wpd.vulkan.window = wd.x11_window;
-				wpd.vulkan.display = x11_display;
-			}
-#endif
-			Error err = rendering_context->window_create(id, &wpd);
-			ERR_FAIL_COND_V_MSG(err != OK, INVALID_WINDOW_ID, vformat("Can't create a %s window", rendering_driver));
-
-			rendering_context->window_set_size(id, win_rect.size.width, win_rect.size.height);
-			rendering_context->window_set_vsync_mode(id, p_vsync_mode);
+#if defined(VULKAN_ENABLED)
+		if (context_vulkan) {
+			Error err = context_vulkan->window_create(id, p_vsync_mode, wd.x11_window, x11_display, win_rect.size.width, win_rect.size.height);
+			ERR_FAIL_COND_V_MSG(err != OK, INVALID_WINDOW_ID, "Can't create a Vulkan window");
 		}
 #endif
 #ifdef GLES3_ENABLED
@@ -6053,13 +5906,8 @@ static ::XIMStyle _get_best_xim_style(const ::XIMStyle &p_style_a, const ::XIMSt
 	return p_style_a;
 }
 
-DisplayServerX11::DisplayServerX11(const String &p_rendering_driver, WindowMode p_mode, VSyncMode p_vsync_mode, uint32_t p_flags, const Vector2i *p_position, const Vector2i &p_resolution, int p_screen, Context p_context, Error &r_error) {
+DisplayServerX11::DisplayServerX11(const String &p_rendering_driver, WindowMode p_mode, VSyncMode p_vsync_mode, uint32_t p_flags, const Vector2i *p_position, const Vector2i &p_resolution, int p_screen, Error &r_error) {
 	KeyMappingX11::initialize();
-
-	xwayland = OS::get_singleton()->get_environment("XDG_SESSION_TYPE").to_lower() == "wayland";
-
-	native_menu = memnew(NativeMenu);
-	context = p_context;
 
 #ifdef SOWRAP_ENABLED
 #ifdef DEBUG_ENABLED
@@ -6355,20 +6203,14 @@ DisplayServerX11::DisplayServerX11(const String &p_rendering_driver, WindowMode 
 	rendering_driver = p_rendering_driver;
 
 	bool driver_found = false;
-#if defined(RD_ENABLED)
 #if defined(VULKAN_ENABLED)
 	if (rendering_driver == "vulkan") {
-		rendering_context = memnew(RenderingContextDriverVulkanX11);
-	}
-#endif
-
-	if (rendering_context) {
-		if (rendering_context->initialize() != OK) {
-			ERR_PRINT(vformat("Could not initialize %s", rendering_driver));
-			memdelete(rendering_context);
-			rendering_context = nullptr;
+		context_vulkan = memnew(VulkanContextX11);
+		if (context_vulkan->initialize() != OK) {
+			memdelete(context_vulkan);
+			context_vulkan = nullptr;
 			r_error = ERR_CANT_CREATE;
-			return;
+			ERR_FAIL_MSG("Could not initialize Vulkan");
 		}
 		driver_found = true;
 	}
@@ -6461,8 +6303,7 @@ DisplayServerX11::DisplayServerX11(const String &p_rendering_driver, WindowMode 
 		if (p_screen == SCREEN_OF_MAIN_WINDOW) {
 			p_screen = SCREEN_PRIMARY;
 		}
-		Rect2i scr_rect = screen_get_usable_rect(p_screen);
-		window_position = scr_rect.position + (scr_rect.size - p_resolution) / 2;
+		window_position = screen_get_position(p_screen) + (screen_get_size(p_screen) - p_resolution) / 2;
 	}
 
 	WindowID main_window = _create_window(p_mode, p_vsync_mode, p_flags, Rect2i(window_position, p_resolution));
@@ -6477,18 +6318,11 @@ DisplayServerX11::DisplayServerX11(const String &p_rendering_driver, WindowMode 
 	}
 	show_window(main_window);
 
-#if defined(RD_ENABLED)
-	if (rendering_context) {
-		rendering_device = memnew(RenderingDevice);
-		if (rendering_device->initialize(rendering_context, MAIN_WINDOW_ID) != OK) {
-			memdelete(rendering_device);
-			rendering_device = nullptr;
-			memdelete(rendering_context);
-			rendering_context = nullptr;
-			r_error = ERR_UNAVAILABLE;
-			return;
-		}
-		rendering_device->screen_create(MAIN_WINDOW_ID);
+#if defined(VULKAN_ENABLED)
+	if (rendering_driver == "vulkan") {
+		//temporary
+		rendering_device_vulkan = memnew(RenderingDeviceVulkan);
+		rendering_device_vulkan->initialize(context_vulkan);
 
 		RendererCompositorRD::make_current();
 	}
@@ -6660,20 +6494,11 @@ DisplayServerX11::~DisplayServerX11() {
 	events_thread_done.set();
 	events_thread.wait_to_finish();
 
-	if (native_menu) {
-		memdelete(native_menu);
-		native_menu = nullptr;
-	}
-
 	//destroy all windows
 	for (KeyValue<WindowID, WindowData> &E : windows) {
-#if defined(RD_ENABLED)
-		if (rendering_device) {
-			rendering_device->screen_free(E.key);
-		}
-
-		if (rendering_context) {
-			rendering_context->window_destroy(E.key);
+#ifdef VULKAN_ENABLED
+		if (context_vulkan) {
+			context_vulkan->window_destroy(E.key);
 		}
 #endif
 #ifdef GLES3_ENABLED
@@ -6715,15 +6540,16 @@ DisplayServerX11::~DisplayServerX11() {
 #endif
 
 	//destroy drivers
-#if defined(RD_ENABLED)
-	if (rendering_device) {
-		memdelete(rendering_device);
-		rendering_device = nullptr;
+#if defined(VULKAN_ENABLED)
+	if (rendering_device_vulkan) {
+		rendering_device_vulkan->finalize();
+		memdelete(rendering_device_vulkan);
+		rendering_device_vulkan = nullptr;
 	}
 
-	if (rendering_context) {
-		memdelete(rendering_context);
-		rendering_context = nullptr;
+	if (context_vulkan) {
+		memdelete(context_vulkan);
+		context_vulkan = nullptr;
 	}
 #endif
 

--- a/platform/linuxbsd/x11/display_server_x11.cpp
+++ b/platform/linuxbsd/x11/display_server_x11.cpp
@@ -42,7 +42,6 @@
 #include "core/string/ustring.h"
 #include "drivers/png/png_driver_common.h"
 #include "main/main.h"
-#include "scene/resources/atlas_texture.h"
 
 #if defined(VULKAN_ENABLED)
 #include "servers/rendering/renderer_rd/renderer_compositor_rd.h"
@@ -121,6 +120,11 @@ static String get_atom_name(Display *p_disp, Atom p_atom) {
 
 bool DisplayServerX11::has_feature(Feature p_feature) const {
 	switch (p_feature) {
+#ifndef DISABLE_DEPRECATED
+		case FEATURE_GLOBAL_MENU: {
+			return (native_menu && native_menu->has_feature(NativeMenu::FEATURE_GLOBAL_MENU));
+		} break;
+#endif
 		case FEATURE_SUBWINDOWS:
 #ifdef TOUCH_ENABLED
 		case FEATURE_TOUCHSCREEN:
@@ -135,8 +139,10 @@ bool DisplayServerX11::has_feature(Feature p_feature) const {
 		//case FEATURE_HIDPI:
 		case FEATURE_ICON:
 #ifdef DBUS_ENABLED
-		case FEATURE_NATIVE_DIALOG:
+		case FEATURE_NATIVE_DIALOG_FILE:
 #endif
+		//case FEATURE_NATIVE_DIALOG:
+		//case FEATURE_NATIVE_DIALOG_INPUT:
 		//case FEATURE_NATIVE_ICON:
 		case FEATURE_SWAP_BUFFERS:
 #ifdef DBUS_ENABLED
@@ -144,9 +150,10 @@ bool DisplayServerX11::has_feature(Feature p_feature) const {
 #endif
 		case FEATURE_CLIPBOARD_PRIMARY:
 		case FEATURE_TEXT_TO_SPEECH:
-		case FEATURE_SCREEN_CAPTURE:
 		case FEATURE_CLIENT_SIDE_DECORATIONS:
 			return true;
+		case FEATURE_SCREEN_CAPTURE:
+			return !xwayland;
 		default: {
 		}
 	}
@@ -376,6 +383,10 @@ bool DisplayServerX11::is_dark_mode() const {
 	}
 }
 
+void DisplayServerX11::set_system_theme_change_callback(const Callable &p_callable) {
+	portal_desktop->set_system_theme_change_callback(p_callable);
+}
+
 Error DisplayServerX11::file_dialog_show(const String &p_title, const String &p_current_directory, const String &p_filename, bool p_show_hidden, FileDialogMode p_mode, const Vector<String> &p_filters, const Callable &p_callback) {
 	WindowID window_id = last_focused_window;
 
@@ -384,7 +395,18 @@ Error DisplayServerX11::file_dialog_show(const String &p_title, const String &p_
 	}
 
 	String xid = vformat("x11:%x", (uint64_t)windows[window_id].x11_window);
-	return portal_desktop->file_dialog_show(last_focused_window, xid, p_title, p_current_directory, p_filename, p_mode, p_filters, p_callback);
+	return portal_desktop->file_dialog_show(last_focused_window, xid, p_title, p_current_directory, String(), p_filename, p_mode, p_filters, TypedArray<Dictionary>(), p_callback, false);
+}
+
+Error DisplayServerX11::file_dialog_with_options_show(const String &p_title, const String &p_current_directory, const String &p_root, const String &p_filename, bool p_show_hidden, FileDialogMode p_mode, const Vector<String> &p_filters, const TypedArray<Dictionary> &p_options, const Callable &p_callback) {
+	WindowID window_id = last_focused_window;
+
+	if (!windows.has(window_id)) {
+		window_id = MAIN_WINDOW_ID;
+	}
+
+	String xid = vformat("x11:%x", (uint64_t)windows[window_id].x11_window);
+	return portal_desktop->file_dialog_show(last_focused_window, xid, p_title, p_current_directory, p_root, p_filename, p_mode, p_filters, p_options, p_callback, true);
 }
 
 #endif
@@ -493,7 +515,34 @@ Point2i DisplayServerX11::mouse_get_position() const {
 }
 
 BitField<MouseButtonMask> DisplayServerX11::mouse_get_button_state() const {
-	return last_button_state;
+	int number_of_screens = XScreenCount(x11_display);
+	for (int i = 0; i < number_of_screens; i++) {
+		Window root, child;
+		int root_x, root_y, win_x, win_y;
+		unsigned int mask;
+		if (XQueryPointer(x11_display, XRootWindow(x11_display, i), &root, &child, &root_x, &root_y, &win_x, &win_y, &mask)) {
+			BitField<MouseButtonMask> last_button_state = 0;
+
+			if (mask & Button1Mask) {
+				last_button_state.set_flag(MouseButtonMask::LEFT);
+			}
+			if (mask & Button2Mask) {
+				last_button_state.set_flag(MouseButtonMask::MIDDLE);
+			}
+			if (mask & Button3Mask) {
+				last_button_state.set_flag(MouseButtonMask::RIGHT);
+			}
+			if (mask & Button4Mask) {
+				last_button_state.set_flag(MouseButtonMask::MB_XBUTTON1);
+			}
+			if (mask & Button5Mask) {
+				last_button_state.set_flag(MouseButtonMask::MB_XBUTTON2);
+			}
+
+			return last_button_state;
+		}
+	}
+	return 0;
 }
 
 void DisplayServerX11::clipboard_set(const String &p_text) {
@@ -998,7 +1047,8 @@ int DisplayServerX11::get_screen_count() const {
 	if (xinerama_ext_ok && XineramaQueryExtension(x11_display, &event_base, &error_base)) {
 		XineramaScreenInfo *xsi = XineramaQueryScreens(x11_display, &count);
 		XFree(xsi);
-	} else {
+	}
+	if (count == 0) {
 		count = XScreenCount(x11_display);
 	}
 
@@ -1059,25 +1109,29 @@ Rect2i DisplayServerX11::_screen_get_rect(int p_screen) const {
 	ERR_FAIL_COND_V(p_screen < 0, rect);
 
 	// Using Xinerama Extension.
+	bool found = false;
 	int event_base, error_base;
 	if (xinerama_ext_ok && XineramaQueryExtension(x11_display, &event_base, &error_base)) {
 		int count;
 		XineramaScreenInfo *xsi = XineramaQueryScreens(x11_display, &count);
-
-		// Check if screen is valid.
-		if (p_screen < count) {
-			rect.position.x = xsi[p_screen].x_org;
-			rect.position.y = xsi[p_screen].y_org;
-			rect.size.width = xsi[p_screen].width;
-			rect.size.height = xsi[p_screen].height;
-		} else {
-			ERR_PRINT("Invalid screen index: " + itos(p_screen) + "(count: " + itos(count) + ").");
-		}
-
 		if (xsi) {
+			if (count > 0) {
+				// Check if screen is valid.
+				if (p_screen < count) {
+					rect.position.x = xsi[p_screen].x_org;
+					rect.position.y = xsi[p_screen].y_org;
+					rect.size.width = xsi[p_screen].width;
+					rect.size.height = xsi[p_screen].height;
+					found = true;
+				} else {
+					ERR_PRINT(vformat("Invalid screen index: %d (count: %d).", p_screen, count));
+				}
+			}
 			XFree(xsi);
 		}
-	} else {
+	}
+
+	if (!found) {
 		int count = XScreenCount(x11_display);
 		if (p_screen < count) {
 			Window root = XRootWindow(x11_display, p_screen);
@@ -1088,7 +1142,7 @@ Rect2i DisplayServerX11::_screen_get_rect(int p_screen) const {
 			rect.size.width = xwa.width;
 			rect.size.height = xwa.height;
 		} else {
-			ERR_PRINT("Invalid screen index: " + itos(p_screen) + "(count: " + itos(count) + ").");
+			ERR_PRINT(vformat("Invalid screen index: %d (count: %d).", p_screen, count));
 		}
 	}
 
@@ -1453,9 +1507,20 @@ int DisplayServerX11::screen_get_dpi(int p_screen) const {
 	return 96;
 }
 
+int get_image_errorhandler(Display *dpy, XErrorEvent *ev) {
+	return 0;
+}
+
 Color DisplayServerX11::screen_get_pixel(const Point2i &p_position) const {
 	Point2i pos = p_position;
 
+	if (xwayland) {
+		return Color();
+	}
+
+	int (*old_handler)(Display *, XErrorEvent *) = XSetErrorHandler(&get_image_errorhandler);
+
+	Color color;
 	int number_of_screens = XScreenCount(x11_display);
 	for (int i = 0; i < number_of_screens; i++) {
 		Window root = XRootWindow(x11_display, i);
@@ -1466,14 +1531,17 @@ Color DisplayServerX11::screen_get_pixel(const Point2i &p_position) const {
 			if (image) {
 				XColor c;
 				c.pixel = XGetPixel(image, 0, 0);
-				XFree(image);
+				XDestroyImage(image);
 				XQueryColor(x11_display, XDefaultColormap(x11_display, i), &c);
-				return Color(float(c.red) / 65535.0, float(c.green) / 65535.0, float(c.blue) / 65535.0, 1.0);
+				color = Color(float(c.red) / 65535.0, float(c.green) / 65535.0, float(c.blue) / 65535.0, 1.0);
+				break;
 			}
 		}
 	}
 
-	return Color();
+	XSetErrorHandler(old_handler);
+
+	return color;
 }
 
 Ref<Image> DisplayServerX11::screen_get_image(int p_screen) const {
@@ -1492,27 +1560,41 @@ Ref<Image> DisplayServerX11::screen_get_image(int p_screen) const {
 
 	ERR_FAIL_COND_V(p_screen < 0, Ref<Image>());
 
+	if (xwayland) {
+		return Ref<Image>();
+	}
+
+	int (*old_handler)(Display *, XErrorEvent *) = XSetErrorHandler(&get_image_errorhandler);
+
 	XImage *image = nullptr;
 
+	bool found = false;
 	int event_base, error_base;
 	if (xinerama_ext_ok && XineramaQueryExtension(x11_display, &event_base, &error_base)) {
 		int xin_count;
 		XineramaScreenInfo *xsi = XineramaQueryScreens(x11_display, &xin_count);
-		if (p_screen < xin_count) {
-			int x_count = XScreenCount(x11_display);
-			for (int i = 0; i < x_count; i++) {
-				Window root = XRootWindow(x11_display, i);
-				XWindowAttributes root_attrs;
-				XGetWindowAttributes(x11_display, root, &root_attrs);
-				if ((xsi[p_screen].x_org >= root_attrs.x) && (xsi[p_screen].x_org <= root_attrs.x + root_attrs.width) && (xsi[p_screen].y_org >= root_attrs.y) && (xsi[p_screen].y_org <= root_attrs.y + root_attrs.height)) {
-					image = XGetImage(x11_display, root, xsi[p_screen].x_org, xsi[p_screen].y_org, xsi[p_screen].width, xsi[p_screen].height, AllPlanes, ZPixmap);
-					break;
+		if (xsi) {
+			if (xin_count > 0) {
+				if (p_screen < xin_count) {
+					int x_count = XScreenCount(x11_display);
+					for (int i = 0; i < x_count; i++) {
+						Window root = XRootWindow(x11_display, i);
+						XWindowAttributes root_attrs;
+						XGetWindowAttributes(x11_display, root, &root_attrs);
+						if ((xsi[p_screen].x_org >= root_attrs.x) && (xsi[p_screen].x_org <= root_attrs.x + root_attrs.width) && (xsi[p_screen].y_org >= root_attrs.y) && (xsi[p_screen].y_org <= root_attrs.y + root_attrs.height)) {
+							found = true;
+							image = XGetImage(x11_display, root, xsi[p_screen].x_org, xsi[p_screen].y_org, xsi[p_screen].width, xsi[p_screen].height, AllPlanes, ZPixmap);
+							break;
+						}
+					}
+				} else {
+					ERR_PRINT(vformat("Invalid screen index: %d (count: %d).", p_screen, xin_count));
 				}
 			}
-		} else {
-			ERR_FAIL_V_MSG(Ref<Image>(), "Invalid screen index: " + itos(p_screen) + "(count: " + itos(xin_count) + ").");
+			XFree(xsi);
 		}
-	} else {
+	}
+	if (!found) {
 		int x_count = XScreenCount(x11_display);
 		if (p_screen < x_count) {
 			Window root = XRootWindow(x11_display, p_screen);
@@ -1522,9 +1604,11 @@ Ref<Image> DisplayServerX11::screen_get_image(int p_screen) const {
 
 			image = XGetImage(x11_display, root, root_attrs.x, root_attrs.y, root_attrs.width, root_attrs.height, AllPlanes, ZPixmap);
 		} else {
-			ERR_FAIL_V_MSG(Ref<Image>(), "Invalid screen index: " + itos(p_screen) + "(count: " + itos(x_count) + ").");
+			ERR_PRINT(vformat("Invalid screen index: %d (count: %d).", p_screen, x_count));
 		}
 	}
+
+	XSetErrorHandler(old_handler);
 
 	Ref<Image> img;
 	if (image) {
@@ -1565,11 +1649,12 @@ Ref<Image> DisplayServerX11::screen_get_image(int p_screen) const {
 				}
 			}
 		} else {
-			XFree(image);
-			ERR_FAIL_V_MSG(Ref<Image>(), vformat("XImage with RGB mask %x %x %x and depth %d is not supported.", (uint64_t)image->red_mask, (uint64_t)image->green_mask, (uint64_t)image->blue_mask, (int64_t)image->bits_per_pixel));
+			String msg = vformat("XImage with RGB mask %x %x %x and depth %d is not supported.", (uint64_t)image->red_mask, (uint64_t)image->green_mask, (uint64_t)image->blue_mask, (int64_t)image->bits_per_pixel);
+			XDestroyImage(image);
+			ERR_FAIL_V_MSG(Ref<Image>(), msg);
 		}
 		img = Image::create_from_data(width, height, false, Image::FORMAT_RGBA8, img_data);
-		XFree(image);
+		XDestroyImage(image);
 	}
 
 	return img;
@@ -1662,7 +1747,7 @@ Vector<DisplayServer::WindowID> DisplayServerX11::get_window_list() const {
 	return ret;
 }
 
-DisplayServer::WindowID DisplayServerX11::create_sub_window(WindowMode p_mode, VSyncMode p_vsync_mode, uint32_t p_flags, const Rect2i &p_rect) {
+DisplayServer::WindowID DisplayServerX11::create_sub_window(WindowMode p_mode, VSyncMode p_vsync_mode, uint32_t p_flags, const Rect2i &p_rect, bool p_exclusive, WindowID p_transient_parent) {
 	_THREAD_SAFE_METHOD_
 
 	WindowID id = _create_window(p_mode, p_vsync_mode, p_flags, p_rect);
@@ -1670,6 +1755,15 @@ DisplayServer::WindowID DisplayServerX11::create_sub_window(WindowMode p_mode, V
 		if (p_flags & (1 << i)) {
 			window_set_flag(WindowFlags(i), true, id);
 		}
+	}
+#ifdef RD_ENABLED
+	if (rendering_device) {
+		rendering_device->screen_create(id);
+	}
+#endif
+
+	if (p_transient_parent != INVALID_WINDOW_ID) {
+		window_set_transient(id, p_transient_parent);
 	}
 
 	return id;
@@ -1719,9 +1813,13 @@ void DisplayServerX11::delete_sub_window(WindowID p_id) {
 		window_set_transient(p_id, INVALID_WINDOW_ID);
 	}
 
-#ifdef VULKAN_ENABLED
-	if (context_vulkan) {
-		context_vulkan->window_destroy(p_id);
+#if defined(RD_ENABLED)
+	if (rendering_device) {
+		rendering_device->screen_free(p_id);
+	}
+
+	if (rendering_context) {
+		rendering_context->window_destroy(p_id);
 	}
 #endif
 #ifdef GLES3_ENABLED
@@ -2018,8 +2116,7 @@ void DisplayServerX11::window_set_current_screen(int p_screen, WindowID p_window
 		Size2i wsize = window_get_size(p_window);
 		wpos += srect.position;
 		if (srect != Rect2i()) {
-			wpos.x = CLAMP(wpos.x, srect.position.x, srect.position.x + srect.size.width - wsize.width / 3);
-			wpos.y = CLAMP(wpos.y, srect.position.y, srect.position.y + srect.size.height - wsize.height / 3);
+			wpos = wpos.clamp(srect.position, srect.position + srect.size - wsize / 3);
 		}
 		window_set_position(wpos, p_window);
 	}
@@ -2060,8 +2157,8 @@ void DisplayServerX11::window_set_transient(WindowID p_window, WindowID p_parent
 		// RevertToPointerRoot is used to make sure we don't lose all focus in case
 		// a subwindow and its parent are both destroyed.
 		if (!wd_window.no_focus && !wd_window.is_popup && wd_window.focused) {
-			if ((xwa.map_state == IsViewable) && !wd_parent.no_focus && !wd_window.is_popup) {
-				XSetInputFocus(x11_display, wd_parent.x11_window, RevertToPointerRoot, CurrentTime);
+			if ((xwa.map_state == IsViewable) && !wd_parent.no_focus && !wd_window.is_popup && _window_focus_check()) {
+				_set_input_focus(wd_parent.x11_window, RevertToPointerRoot);
 			}
 		}
 	} else {
@@ -2247,8 +2344,7 @@ void DisplayServerX11::window_set_size(const Size2i p_size, WindowID p_window) {
 	ERR_FAIL_COND(!windows.has(p_window));
 
 	Size2i size = p_size;
-	size.x = MAX(1, size.x);
-	size.y = MAX(1, size.y);
+	size = size.maxi(1);
 
 	WindowData &wd = windows[p_window];
 
@@ -2279,13 +2375,13 @@ void DisplayServerX11::window_set_size(const Size2i p_size, WindowID p_window) {
 			break;
 		}
 
-		usleep(10000);
+		OS::get_singleton()->delay_usec(10'000);
 	}
 
 	// Keep rendering context window size in sync
-#if defined(VULKAN_ENABLED)
-	if (context_vulkan) {
-		context_vulkan->window_resize(p_window, xwa.width, xwa.height);
+#if defined(RD_ENABLED)
+	if (rendering_context) {
+		rendering_context->window_set_size(p_window, xwa.width, xwa.height);
 	}
 #endif
 #if defined(GLES3_ENABLED)
@@ -2554,7 +2650,7 @@ void DisplayServerX11::_set_wm_maximized(WindowID p_window, bool p_enabled) {
 		// Give up after 0.5s, it's not going to happen on this WM.
 		// https://github.com/godotengine/godot/issues/19978
 		for (int attempt = 0; window_get_mode(p_window) != WINDOW_MODE_MAXIMIZED && attempt < 50; attempt++) {
-			usleep(10000);
+			OS::get_singleton()->delay_usec(10'000);
 		}
 	}
 	wd.maximized = p_enabled;
@@ -2941,10 +3037,15 @@ void DisplayServerX11::window_move_to_foreground(WindowID p_window) {
 	XFlush(x11_display);
 }
 
+DisplayServerX11::WindowID DisplayServerX11::get_focused_window() const {
+	return last_focused_window;
+}
+
 bool DisplayServerX11::window_is_focused(WindowID p_window) const {
 	_THREAD_SAFE_METHOD_
 
 	ERR_FAIL_COND_V(!windows.has(p_window), false);
+
 	const WindowData &wd = windows[p_window];
 
 	return wd.focused;
@@ -2996,7 +3097,7 @@ void DisplayServerX11::window_set_ime_active(const bool p_active, WindowID p_win
 		XSync(x11_display, False);
 		XGetWindowAttributes(x11_display, wd.x11_xim_window, &xwa);
 		if (xwa.map_state == IsViewable) {
-			XSetInputFocus(x11_display, wd.x11_xim_window, RevertToParent, CurrentTime);
+			_set_input_focus(wd.x11_xim_window, RevertToParent);
 		}
 		XSetICFocus(wd.xic);
 	} else {
@@ -3086,39 +3187,9 @@ void DisplayServerX11::cursor_set_custom_image(const Ref<Resource> &p_cursor, Cu
 			cursors_cache.erase(p_shape);
 		}
 
-		Ref<Texture2D> texture = p_cursor;
-		ERR_FAIL_COND(!texture.is_valid());
-		Ref<AtlasTexture> atlas_texture = p_cursor;
-		Size2i texture_size;
-		Rect2i atlas_rect;
-
-		if (atlas_texture.is_valid()) {
-			texture = atlas_texture->get_atlas();
-
-			atlas_rect.size.width = texture->get_width();
-			atlas_rect.size.height = texture->get_height();
-			atlas_rect.position.x = atlas_texture->get_region().position.x;
-			atlas_rect.position.y = atlas_texture->get_region().position.y;
-
-			texture_size.width = atlas_texture->get_region().size.x;
-			texture_size.height = atlas_texture->get_region().size.y;
-		} else {
-			texture_size.width = texture->get_width();
-			texture_size.height = texture->get_height();
-		}
-
-		ERR_FAIL_COND(p_hotspot.x < 0 || p_hotspot.y < 0);
-		ERR_FAIL_COND(texture_size.width > 256 || texture_size.height > 256);
-		ERR_FAIL_COND(p_hotspot.x > texture_size.width || p_hotspot.y > texture_size.height);
-
-		Ref<Image> image = texture->get_image();
-
-		ERR_FAIL_COND(!image.is_valid());
-		if (image->is_compressed()) {
-			image = image->duplicate(true);
-			Error err = image->decompress();
-			ERR_FAIL_COND_MSG(err != OK, "Couldn't decompress VRAM-compressed custom mouse cursor image. Switch to a lossless compression mode in the Import dock.");
-		}
+		Ref<Image> image = _get_cursor_image_from_resource(p_cursor, p_hotspot);
+		ERR_FAIL_COND(image.is_null());
+		Vector2i texture_size = image->get_size();
 
 		// Create the cursor structure
 		XcursorImage *cursor_image = XcursorImageCreate(texture_size.width, texture_size.height);
@@ -3134,13 +3205,8 @@ void DisplayServerX11::cursor_set_custom_image(const Ref<Resource> &p_cursor, Cu
 		cursor_image->pixels = (XcursorPixel *)memalloc(size);
 
 		for (XcursorPixel index = 0; index < image_size; index++) {
-			int row_index = floor(index / texture_size.width) + atlas_rect.position.y;
-			int column_index = (index % int(texture_size.width)) + atlas_rect.position.x;
-
-			if (atlas_texture.is_valid()) {
-				column_index = MIN(column_index, atlas_rect.size.width - 1);
-				row_index = MIN(row_index, atlas_rect.size.height - 1);
-			}
+			int row_index = floor(index / texture_size.width);
+			int column_index = index % int(texture_size.width);
 
 			*(cursor_image->pixels + index) = image->get_pixel(column_index, row_index).to_argb32();
 		}
@@ -3385,18 +3451,6 @@ void DisplayServerX11::_get_key_modifier_state(unsigned int p_x11_state, Ref<Inp
 	state->set_meta_pressed((p_x11_state & Mod4Mask));
 }
 
-BitField<MouseButtonMask> DisplayServerX11::_get_mouse_button_state(MouseButton p_x11_button, int p_x11_type) {
-	MouseButtonMask mask = mouse_button_to_mask(p_x11_button);
-
-	if (p_x11_type == ButtonPress) {
-		last_button_state.set_flag(mask);
-	} else {
-		last_button_state.clear_flag(mask);
-	}
-
-	return last_button_state;
-}
-
 void DisplayServerX11::_handle_key_event(WindowID p_window, XKeyEvent *p_event, LocalVector<XEvent> &p_events, uint32_t &p_event_index, bool p_echo) {
 	WindowData &wd = windows[p_window];
 	// X11 functions don't know what const is
@@ -3546,6 +3600,7 @@ void DisplayServerX11::_handle_key_event(WindowID p_window, XKeyEvent *p_event, 
 				bool keypress = xkeyevent->type == KeyPress;
 				Key keycode = KeyMappingX11::get_keycode(keysym_keycode);
 				Key physical_keycode = KeyMappingX11::get_scancode(xkeyevent->keycode);
+				KeyLocation key_location = KeyMappingX11::get_location(xkeyevent->keycode);
 
 				if (keycode >= Key::A + 32 && keycode <= Key::Z + 32) {
 					keycode -= 'a' - 'A';
@@ -3583,6 +3638,8 @@ void DisplayServerX11::_handle_key_event(WindowID p_window, XKeyEvent *p_event, 
 						k->set_unicode(fix_unicode(tmp[i]));
 					}
 
+					k->set_location(key_location);
+
 					k->set_echo(false);
 
 					if (k->get_keycode() == Key::BACKTAB) {
@@ -3607,6 +3664,8 @@ void DisplayServerX11::_handle_key_event(WindowID p_window, XKeyEvent *p_event, 
 
 	Key keycode = KeyMappingX11::get_keycode(keysym_keycode);
 	Key physical_keycode = KeyMappingX11::get_scancode(xkeyevent->keycode);
+
+	KeyLocation key_location = KeyMappingX11::get_location(xkeyevent->keycode);
 
 	/* Phase 3, obtain a unicode character from the keysym */
 
@@ -3707,6 +3766,9 @@ void DisplayServerX11::_handle_key_event(WindowID p_window, XKeyEvent *p_event, 
 	if (keypress) {
 		k->set_unicode(fix_unicode(unicode));
 	}
+
+	k->set_location(key_location);
+
 	k->set_echo(p_echo);
 
 	if (k->get_keycode() == Key::BACKTAB) {
@@ -3925,7 +3987,7 @@ void DisplayServerX11::_xim_preedit_draw_callback(::XIM xim, ::XPointer client_d
 			ds->im_selection = Point2i();
 		}
 
-		OS_Unix::get_singleton()->get_main_loop()->notification(MainLoop::NOTIFICATION_OS_IME_UPDATE);
+		callable_mp((Object *)OS_Unix::get_singleton()->get_main_loop(), &Object::notification).call_deferred(MainLoop::NOTIFICATION_OS_IME_UPDATE, false);
 	}
 }
 
@@ -3995,9 +4057,9 @@ void DisplayServerX11::_window_changed(XEvent *event) {
 	wd.position = new_rect.position;
 	wd.size = new_rect.size;
 
-#if defined(VULKAN_ENABLED)
-	if (context_vulkan) {
-		context_vulkan->window_resize(window_id, wd.size.width, wd.size.height);
+#if defined(RD_ENABLED)
+	if (rendering_context) {
+		rendering_context->window_set_size(window_id, wd.size.width, wd.size.height);
 	}
 #endif
 #if defined(GLES3_ENABLED)
@@ -4066,6 +4128,18 @@ void DisplayServerX11::_send_window_event(const WindowData &wd, WindowEvent p_ev
 	if (wd.event_callback.is_valid()) {
 		Variant event = int(p_event);
 		wd.event_callback.call(event);
+	}
+}
+
+void DisplayServerX11::_set_input_focus(Window p_window, int p_revert_to) {
+	Window focused_window;
+	int focus_ret_state;
+	XGetInputFocus(x11_display, &focused_window, &focus_ret_state);
+
+	// Only attempt to change focus if the window isn't already focused, in order to
+	// prevent issues with Godot stealing input focus with alternative window managers.
+	if (p_window != focused_window) {
+		XSetInputFocus(x11_display, p_window, p_revert_to, CurrentTime);
 	}
 }
 
@@ -4189,8 +4263,11 @@ void DisplayServerX11::popup_open(WindowID p_window) {
 		}
 	}
 
+	// Detect tooltips and other similar popups that shouldn't block input to their parent.
+	bool ignores_input = window_get_flag(WINDOW_FLAG_NO_FOCUS, p_window) && window_get_flag(WINDOW_FLAG_MOUSE_PASSTHROUGH, p_window);
+
 	WindowData &wd = windows[p_window];
-	if (wd.is_popup || has_popup_ancestor) {
+	if (wd.is_popup || (has_popup_ancestor && !ignores_input)) {
 		// Find current popup parent, or root popup if new window is not transient.
 		List<WindowID>::Element *C = nullptr;
 		List<WindowID>::Element *E = popup_list.back();
@@ -4220,7 +4297,10 @@ void DisplayServerX11::popup_close(WindowID p_window) {
 		WindowID win_id = E->get();
 		popup_list.erase(E);
 
-		_send_window_event(windows[win_id], DisplayServerX11::WINDOW_EVENT_CLOSE_REQUEST);
+		if (win_id != p_window) {
+			// Only request close on related windows, not this window.  We are already processing it.
+			_send_window_event(windows[win_id], DisplayServerX11::WINDOW_EVENT_CLOSE_REQUEST);
+		}
 		E = F;
 	}
 }
@@ -4278,6 +4358,22 @@ bool DisplayServerX11::mouse_process_popups() {
 	return closed;
 }
 
+bool DisplayServerX11::_window_focus_check() {
+	Window focused_window;
+	int focus_ret_state;
+	XGetInputFocus(x11_display, &focused_window, &focus_ret_state);
+
+	bool has_focus = false;
+	for (const KeyValue<int, DisplayServerX11::WindowData> &wid : windows) {
+		if (wid.value.x11_window == focused_window) {
+			has_focus = true;
+			break;
+		}
+	}
+
+	return has_focus;
+}
+
 void DisplayServerX11::_process_window_drag(WindowID p_window, XEvent p_event, int p_dec_type) {
 	XClientMessageEvent m;
 	memset(&m, 0, sizeof(m));
@@ -4300,7 +4396,9 @@ void DisplayServerX11::_process_window_drag(WindowID p_window, XEvent p_event, i
 }
 
 void DisplayServerX11::process_events() {
-	_THREAD_SAFE_METHOD_
+	ERR_FAIL_COND(!Thread::is_main_thread());
+
+	_THREAD_SAFE_LOCK_
 
 #ifdef DISPLAY_SERVER_X11_DEBUG_LOGS_ENABLED
 	static int frame = 0;
@@ -4543,6 +4641,7 @@ void DisplayServerX11::process_events() {
 							sd->set_index(index);
 							sd->set_position(pos);
 							sd->set_relative(pos - curr_pos_elem->value);
+							sd->set_relative_screen_position(sd->get_relative());
 							Input::get_singleton()->parse_input_event(sd);
 
 							curr_pos_elem->value = pos;
@@ -4570,8 +4669,8 @@ void DisplayServerX11::process_events() {
 				// Set focus when menu window is started.
 				// RevertToPointerRoot is used to make sure we don't lose all focus in case
 				// a subwindow and its parent are both destroyed.
-				if ((xwa.map_state == IsViewable) && !wd.no_focus && !wd.is_popup) {
-					XSetInputFocus(x11_display, wd.x11_window, RevertToPointerRoot, CurrentTime);
+				if ((xwa.map_state == IsViewable) && !wd.no_focus && !wd.is_popup && _window_focus_check()) {
+					_set_input_focus(wd.x11_window, RevertToPointerRoot);
 				}
 
 				// Have we failed to set fullscreen while the window was unmapped?
@@ -4737,22 +4836,8 @@ void DisplayServerX11::process_events() {
 					break;
 				}
 
-				const WindowData &wd = windows[window_id];
-
-				XWindowAttributes xwa;
-				XSync(x11_display, False);
-				XGetWindowAttributes(x11_display, wd.x11_window, &xwa);
-
-				// Set focus when menu window is re-used.
-				// RevertToPointerRoot is used to make sure we don't lose all focus in case
-				// a subwindow and its parent are both destroyed.
-				if ((xwa.map_state == IsViewable) && !wd.no_focus && !wd.is_popup) {
-					XSetInputFocus(x11_display, wd.x11_window, RevertToPointerRoot, CurrentTime);
-				}
-
 				_window_changed(&event);
 			} break;
-
 			case ButtonPress: {
 				if (event.xbutton.button == 1) {
 					bool drag_event = false;
@@ -4792,8 +4877,79 @@ void DisplayServerX11::process_events() {
 									drag_event = true;
 								} break;
 								case DisplayServer::WINDOW_DECORATION_MOVE: {
-									_process_window_drag(window_id, event, _NET_WM_MOVERESIZE_MOVE);
-									//drag_event = true;
+									if (ime_window_event || ignore_events) {
+										break;
+									}
+									/* exit in case of a mouse button press */
+									last_timestamp = event.xbutton.time;
+									if (mouse_mode == MOUSE_MODE_CAPTURED) {
+										event.xbutton.x = last_mouse_pos.x;
+										event.xbutton.y = last_mouse_pos.y;
+									}
+
+									Ref<InputEventMouseButton> mb;
+									mb.instantiate();
+
+									mb->set_window_id(window_id);
+									_get_key_modifier_state(event.xbutton.state, mb);
+									mb->set_button_index((MouseButton)event.xbutton.button);
+									if (mb->get_button_index() == MouseButton::RIGHT) {
+										mb->set_button_index(MouseButton::MIDDLE);
+									} else if (mb->get_button_index() == MouseButton::MIDDLE) {
+										mb->set_button_index(MouseButton::RIGHT);
+									}
+									mb->set_position(Vector2(event.xbutton.x, event.xbutton.y));
+									mb->set_global_position(mb->get_position());
+
+									mb->set_pressed((event.type == ButtonPress));
+
+									if (mb->is_pressed() && mb->get_button_index() >= MouseButton::WHEEL_UP && mb->get_button_index() <= MouseButton::WHEEL_RIGHT) {
+										MouseButtonMask mask = mouse_button_to_mask(mb->get_button_index());
+										BitField<MouseButtonMask> scroll_mask = mouse_get_button_state();
+										scroll_mask.set_flag(mask);
+										mb->set_button_mask(scroll_mask);
+									} else {
+										mb->set_button_mask(mouse_get_button_state());
+									}
+
+									const WindowData &wd = windows[window_id];
+
+									if (event.type == ButtonPress) {
+										DEBUG_LOG_X11("[%u] ButtonPress window=%lu (%u), button_index=%u \n", frame, event.xbutton.window, window_id, mb->get_button_index());
+
+										// Ensure window focus on click.
+										// RevertToPointerRoot is used to make sure we don't lose all focus in case
+										// a subwindow and its parent are both destroyed.
+										if (!wd.no_focus && !wd.is_popup) {
+											_set_input_focus(wd.x11_window, RevertToPointerRoot);
+										}
+
+										uint64_t diff = OS::get_singleton()->get_ticks_usec() / 1000 - last_click_ms;
+
+										if (mb->get_button_index() == last_click_button_index) {
+											if (diff < 400 && Vector2(last_click_pos).distance_to(Vector2(event.xbutton.x, event.xbutton.y)) < 5) {
+												last_click_ms = 0;
+												last_click_pos = Point2i(-100, -100);
+												last_click_button_index = MouseButton::NONE;
+												mb->set_double_click(true);
+											}
+
+										} else if (mb->get_button_index() < MouseButton::WHEEL_UP || mb->get_button_index() > MouseButton::WHEEL_RIGHT) {
+											last_click_button_index = mb->get_button_index();
+										}
+
+										if (!mb->is_double_click()) {
+											last_click_ms += diff;
+											last_click_pos = Point2i(event.xbutton.x, event.xbutton.y);
+										}
+									}
+
+									if (event.xbutton.button == 1 && mb->is_double_click()) {
+										_set_wm_maximized(window_id, !_window_maximize_check(window_id, "_NET_WM_STATE"));
+									} else {
+										_process_window_drag(window_id, event, _NET_WM_MOVERESIZE_MOVE);
+									}
+									drag_event = true;
 								} break;
 								default:
 									break;
@@ -4829,11 +4985,19 @@ void DisplayServerX11::process_events() {
 				} else if (mb->get_button_index() == MouseButton::MIDDLE) {
 					mb->set_button_index(MouseButton::RIGHT);
 				}
-				mb->set_button_mask(_get_mouse_button_state(mb->get_button_index(), event.xbutton.type));
 				mb->set_position(Vector2(event.xbutton.x, event.xbutton.y));
 				mb->set_global_position(mb->get_position());
 
 				mb->set_pressed((event.type == ButtonPress));
+
+				if (mb->is_pressed() && mb->get_button_index() >= MouseButton::WHEEL_UP && mb->get_button_index() <= MouseButton::WHEEL_RIGHT) {
+					MouseButtonMask mask = mouse_button_to_mask(mb->get_button_index());
+					BitField<MouseButtonMask> scroll_mask = mouse_get_button_state();
+					scroll_mask.set_flag(mask);
+					mb->set_button_mask(scroll_mask);
+				} else {
+					mb->set_button_mask(mouse_get_button_state());
+				}
 
 				const WindowData &wd = windows[window_id];
 
@@ -4844,7 +5008,7 @@ void DisplayServerX11::process_events() {
 					// RevertToPointerRoot is used to make sure we don't lose all focus in case
 					// a subwindow and its parent are both destroyed.
 					if (!wd.no_focus && !wd.is_popup) {
-						XSetInputFocus(x11_display, wd.x11_window, RevertToPointerRoot, CurrentTime);
+						_set_input_focus(wd.x11_window, RevertToPointerRoot);
 					}
 
 					uint64_t diff = OS::get_singleton()->get_ticks_usec() / 1000 - last_click_ms;
@@ -4864,20 +5028,6 @@ void DisplayServerX11::process_events() {
 					if (!mb->is_double_click()) {
 						last_click_ms += diff;
 						last_click_pos = Point2i(event.xbutton.x, event.xbutton.y);
-					}
-
-					if (event.xbutton.button == 1 && mb->is_double_click()) {
-						for (const KeyValue<int, DisplayServerX11::DecorData> &E : windows[window_id].decor) {
-							if (Geometry2D::is_point_in_polygon(Vector2i(event.xbutton.x, event.xbutton.y), E.value.region)) {
-								switch (E.value.dec_type) {
-									case DisplayServer::WINDOW_DECORATION_MOVE: {
-										_set_wm_maximized(window_id, !_window_maximize_check(window_id, "_NET_WM_STATE"));
-									} break;
-									default:
-										break;
-								}
-							}
-						}
 					}
 
 				} else {
@@ -5015,6 +5165,23 @@ void DisplayServerX11::process_events() {
 					pos = Point2i(windows[focused_window_id].size.width / 2, windows[focused_window_id].size.height / 2);
 				}
 
+				BitField<MouseButtonMask> last_button_state = 0;
+				if (event.xmotion.state & Button1Mask) {
+					last_button_state.set_flag(MouseButtonMask::LEFT);
+				}
+				if (event.xmotion.state & Button2Mask) {
+					last_button_state.set_flag(MouseButtonMask::MIDDLE);
+				}
+				if (event.xmotion.state & Button3Mask) {
+					last_button_state.set_flag(MouseButtonMask::RIGHT);
+				}
+				if (event.xmotion.state & Button4Mask) {
+					last_button_state.set_flag(MouseButtonMask::MB_XBUTTON1);
+				}
+				if (event.xmotion.state & Button5Mask) {
+					last_button_state.set_flag(MouseButtonMask::MB_XBUTTON2);
+				}
+
 				Ref<InputEventMouseMotion> mm;
 				mm.instantiate();
 
@@ -5022,18 +5189,20 @@ void DisplayServerX11::process_events() {
 				if (xi.pressure_supported) {
 					mm->set_pressure(xi.pressure);
 				} else {
-					mm->set_pressure(bool(mouse_get_button_state().has_flag(MouseButtonMask::LEFT)) ? 1.0f : 0.0f);
+					mm->set_pressure(bool(last_button_state.has_flag(MouseButtonMask::LEFT)) ? 1.0f : 0.0f);
 				}
 				mm->set_tilt(xi.tilt);
 				mm->set_pen_inverted(xi.pen_inverted);
 
 				_get_key_modifier_state(event.xmotion.state, mm);
-				mm->set_button_mask(mouse_get_button_state());
+				mm->set_button_mask(last_button_state);
 				mm->set_position(pos);
 				mm->set_global_position(pos);
 				mm->set_velocity(Input::get_singleton()->get_last_mouse_velocity());
+				mm->set_screen_velocity(mm->get_velocity());
 
 				mm->set_relative(rel);
+				mm->set_relative_screen_position(rel);
 
 				last_mouse_pos = pos;
 
@@ -5102,8 +5271,15 @@ void DisplayServerX11::process_events() {
 						files.write[i] = files[i].replace("file://", "").uri_decode();
 					}
 
-					if (!windows[window_id].drop_files_callback.is_null()) {
-						windows[window_id].drop_files_callback.call(files);
+					if (windows[window_id].drop_files_callback.is_valid()) {
+						Variant v_files = files;
+						const Variant *v_args[1] = { &v_files };
+						Variant ret;
+						Callable::CallError ce;
+						windows[window_id].drop_files_callback.callp((const Variant **)&v_args, 1, ret, ce);
+						if (ce.error != Callable::CallError::CALL_OK) {
+							ERR_PRINT(vformat("Failed to execute drop files callback: %s.", Variant::get_callable_error_text(windows[window_id].drop_files_callback, v_args, 1, ce)));
+						}
 					}
 
 					//Reply that all is well.
@@ -5207,6 +5383,14 @@ void DisplayServerX11::process_events() {
 		*/
 	}
 
+#ifdef DBUS_ENABLED
+	if (portal_desktop) {
+		portal_desktop->process_file_dialog_callbacks();
+	}
+#endif
+
+	_THREAD_SAFE_UNLOCK_
+
 	Input::get_singleton()->flush_buffered_events();
 }
 
@@ -5217,17 +5401,6 @@ void DisplayServerX11::release_rendering_thread() {
 	}
 	if (gl_manager_egl) {
 		gl_manager_egl->release_current();
-	}
-#endif
-}
-
-void DisplayServerX11::make_rendering_thread() {
-#if defined(GLES3_ENABLED)
-	if (gl_manager) {
-		gl_manager->make_current();
-	}
-	if (gl_manager_egl) {
-		gl_manager_egl->make_current();
 	}
 #endif
 }
@@ -5290,6 +5463,23 @@ void DisplayServerX11::set_context(Context p_context) {
 	}
 }
 
+bool DisplayServerX11::is_window_transparency_available() const {
+	CharString net_wm_cm_name = vformat("_NET_WM_CM_S%d", XDefaultScreen(x11_display)).ascii();
+	Atom net_wm_cm = XInternAtom(x11_display, net_wm_cm_name.get_data(), False);
+	if (net_wm_cm == None) {
+		return false;
+	}
+	if (XGetSelectionOwner(x11_display, net_wm_cm) == None) {
+		return false;
+	}
+#if defined(RD_ENABLED)
+	if (rendering_device && !rendering_device->is_composite_alpha_supported()) {
+		return false;
+	}
+#endif
+	return OS::get_singleton()->is_layered_allowed();
+}
+
 void DisplayServerX11::set_native_icon(const String &p_filename) {
 	WARN_PRINT("Native icon not supported by this display server.");
 }
@@ -5322,7 +5512,7 @@ void DisplayServerX11::set_icon(const Ref<Image> &p_icon) {
 			if (g_set_icon_error) {
 				g_set_icon_error = false;
 
-				WARN_PRINT("Icon too large, attempting to resize icon.");
+				WARN_PRINT(vformat("Icon too large (%dx%d), attempting to downscale icon.", w, h));
 
 				int new_width, new_height;
 				if (w > h) {
@@ -5383,9 +5573,9 @@ void DisplayServerX11::set_icon(const Ref<Image> &p_icon) {
 
 void DisplayServerX11::window_set_vsync_mode(DisplayServer::VSyncMode p_vsync_mode, WindowID p_window) {
 	_THREAD_SAFE_METHOD_
-#if defined(VULKAN_ENABLED)
-	if (context_vulkan) {
-		context_vulkan->set_vsync_mode(p_window, p_vsync_mode);
+#if defined(RD_ENABLED)
+	if (rendering_context) {
+		rendering_context->window_set_vsync_mode(p_window, p_vsync_mode);
 	}
 #endif
 
@@ -5401,9 +5591,9 @@ void DisplayServerX11::window_set_vsync_mode(DisplayServer::VSyncMode p_vsync_mo
 
 DisplayServer::VSyncMode DisplayServerX11::window_get_vsync_mode(WindowID p_window) const {
 	_THREAD_SAFE_METHOD_
-#if defined(VULKAN_ENABLED)
-	if (context_vulkan) {
-		return context_vulkan->get_vsync_mode(p_window);
+#if defined(RD_ENABLED)
+	if (rendering_context) {
+		return rendering_context->window_get_vsync_mode(p_window);
 	}
 #endif
 #if defined(GLES3_ENABLED)
@@ -5431,8 +5621,8 @@ Vector<String> DisplayServerX11::get_rendering_drivers_func() {
 	return drivers;
 }
 
-DisplayServer *DisplayServerX11::create_func(const String &p_rendering_driver, WindowMode p_mode, VSyncMode p_vsync_mode, uint32_t p_flags, const Vector2i *p_position, const Vector2i &p_resolution, int p_screen, Error &r_error) {
-	DisplayServer *ds = memnew(DisplayServerX11(p_rendering_driver, p_mode, p_vsync_mode, p_flags, p_position, p_resolution, p_screen, r_error));
+DisplayServer *DisplayServerX11::create_func(const String &p_rendering_driver, WindowMode p_mode, VSyncMode p_vsync_mode, uint32_t p_flags, const Vector2i *p_position, const Vector2i &p_resolution, int p_screen, Context p_context, Error &r_error) {
+	DisplayServer *ds = memnew(DisplayServerX11(p_rendering_driver, p_mode, p_vsync_mode, p_flags, p_position, p_resolution, p_screen, p_context, r_error));
 	if (r_error != OK) {
 		if (p_rendering_driver == "vulkan") {
 			String executable_name = OS::get_singleton()->get_executable_path().get_file();
@@ -5561,8 +5751,7 @@ DisplayServerX11::WindowID DisplayServerX11::_create_window(WindowMode p_mode, V
 	} else {
 		Rect2i srect = screen_get_usable_rect(rq_screen);
 		Point2i wpos = p_rect.position;
-		wpos.x = CLAMP(wpos.x, srect.position.x, srect.position.x + srect.size.width - p_rect.size.width / 3);
-		wpos.y = CLAMP(wpos.y, srect.position.y, srect.position.y + srect.size.height - p_rect.size.height / 3);
+		wpos = wpos.clamp(srect.position, srect.position + srect.size - p_rect.size / 3);
 
 		win_rect.position = wpos;
 	}
@@ -5745,10 +5934,24 @@ DisplayServerX11::WindowID DisplayServerX11::_create_window(WindowMode p_mode, V
 
 		_update_size_hints(id);
 
-#if defined(VULKAN_ENABLED)
-		if (context_vulkan) {
-			Error err = context_vulkan->window_create(id, p_vsync_mode, wd.x11_window, x11_display, win_rect.size.width, win_rect.size.height);
-			ERR_FAIL_COND_V_MSG(err != OK, INVALID_WINDOW_ID, "Can't create a Vulkan window");
+#if defined(RD_ENABLED)
+		if (rendering_context) {
+			union {
+#ifdef VULKAN_ENABLED
+				RenderingContextDriverVulkanX11::WindowPlatformData vulkan;
+#endif
+			} wpd;
+#ifdef VULKAN_ENABLED
+			if (rendering_driver == "vulkan") {
+				wpd.vulkan.window = wd.x11_window;
+				wpd.vulkan.display = x11_display;
+			}
+#endif
+			Error err = rendering_context->window_create(id, &wpd);
+			ERR_FAIL_COND_V_MSG(err != OK, INVALID_WINDOW_ID, vformat("Can't create a %s window", rendering_driver));
+
+			rendering_context->window_set_size(id, win_rect.size.width, win_rect.size.height);
+			rendering_context->window_set_vsync_mode(id, p_vsync_mode);
 		}
 #endif
 #ifdef GLES3_ENABLED
@@ -5850,8 +6053,13 @@ static ::XIMStyle _get_best_xim_style(const ::XIMStyle &p_style_a, const ::XIMSt
 	return p_style_a;
 }
 
-DisplayServerX11::DisplayServerX11(const String &p_rendering_driver, WindowMode p_mode, VSyncMode p_vsync_mode, uint32_t p_flags, const Vector2i *p_position, const Vector2i &p_resolution, int p_screen, Error &r_error) {
+DisplayServerX11::DisplayServerX11(const String &p_rendering_driver, WindowMode p_mode, VSyncMode p_vsync_mode, uint32_t p_flags, const Vector2i *p_position, const Vector2i &p_resolution, int p_screen, Context p_context, Error &r_error) {
 	KeyMappingX11::initialize();
+
+	xwayland = OS::get_singleton()->get_environment("XDG_SESSION_TYPE").to_lower() == "wayland";
+
+	native_menu = memnew(NativeMenu);
+	context = p_context;
 
 #ifdef SOWRAP_ENABLED
 #ifdef DEBUG_ENABLED
@@ -6147,14 +6355,20 @@ DisplayServerX11::DisplayServerX11(const String &p_rendering_driver, WindowMode 
 	rendering_driver = p_rendering_driver;
 
 	bool driver_found = false;
+#if defined(RD_ENABLED)
 #if defined(VULKAN_ENABLED)
 	if (rendering_driver == "vulkan") {
-		context_vulkan = memnew(VulkanContextX11);
-		if (context_vulkan->initialize() != OK) {
-			memdelete(context_vulkan);
-			context_vulkan = nullptr;
+		rendering_context = memnew(RenderingContextDriverVulkanX11);
+	}
+#endif
+
+	if (rendering_context) {
+		if (rendering_context->initialize() != OK) {
+			ERR_PRINT(vformat("Could not initialize %s", rendering_driver));
+			memdelete(rendering_context);
+			rendering_context = nullptr;
 			r_error = ERR_CANT_CREATE;
-			ERR_FAIL_MSG("Could not initialize Vulkan");
+			return;
 		}
 		driver_found = true;
 	}
@@ -6247,7 +6461,8 @@ DisplayServerX11::DisplayServerX11(const String &p_rendering_driver, WindowMode 
 		if (p_screen == SCREEN_OF_MAIN_WINDOW) {
 			p_screen = SCREEN_PRIMARY;
 		}
-		window_position = screen_get_position(p_screen) + (screen_get_size(p_screen) - p_resolution) / 2;
+		Rect2i scr_rect = screen_get_usable_rect(p_screen);
+		window_position = scr_rect.position + (scr_rect.size - p_resolution) / 2;
 	}
 
 	WindowID main_window = _create_window(p_mode, p_vsync_mode, p_flags, Rect2i(window_position, p_resolution));
@@ -6262,11 +6477,18 @@ DisplayServerX11::DisplayServerX11(const String &p_rendering_driver, WindowMode 
 	}
 	show_window(main_window);
 
-#if defined(VULKAN_ENABLED)
-	if (rendering_driver == "vulkan") {
-		//temporary
-		rendering_device_vulkan = memnew(RenderingDeviceVulkan);
-		rendering_device_vulkan->initialize(context_vulkan);
+#if defined(RD_ENABLED)
+	if (rendering_context) {
+		rendering_device = memnew(RenderingDevice);
+		if (rendering_device->initialize(rendering_context, MAIN_WINDOW_ID) != OK) {
+			memdelete(rendering_device);
+			rendering_device = nullptr;
+			memdelete(rendering_context);
+			rendering_context = nullptr;
+			r_error = ERR_UNAVAILABLE;
+			return;
+		}
+		rendering_device->screen_create(MAIN_WINDOW_ID);
 
 		RendererCompositorRD::make_current();
 	}
@@ -6438,11 +6660,20 @@ DisplayServerX11::~DisplayServerX11() {
 	events_thread_done.set();
 	events_thread.wait_to_finish();
 
+	if (native_menu) {
+		memdelete(native_menu);
+		native_menu = nullptr;
+	}
+
 	//destroy all windows
 	for (KeyValue<WindowID, WindowData> &E : windows) {
-#ifdef VULKAN_ENABLED
-		if (context_vulkan) {
-			context_vulkan->window_destroy(E.key);
+#if defined(RD_ENABLED)
+		if (rendering_device) {
+			rendering_device->screen_free(E.key);
+		}
+
+		if (rendering_context) {
+			rendering_context->window_destroy(E.key);
 		}
 #endif
 #ifdef GLES3_ENABLED
@@ -6484,16 +6715,15 @@ DisplayServerX11::~DisplayServerX11() {
 #endif
 
 	//destroy drivers
-#if defined(VULKAN_ENABLED)
-	if (rendering_device_vulkan) {
-		rendering_device_vulkan->finalize();
-		memdelete(rendering_device_vulkan);
-		rendering_device_vulkan = nullptr;
+#if defined(RD_ENABLED)
+	if (rendering_device) {
+		memdelete(rendering_device);
+		rendering_device = nullptr;
 	}
 
-	if (context_vulkan) {
-		memdelete(context_vulkan);
-		context_vulkan = nullptr;
+	if (rendering_context) {
+		memdelete(rendering_context);
+		rendering_context = nullptr;
 	}
 #endif
 

--- a/platform/linuxbsd/x11/display_server_x11.h
+++ b/platform/linuxbsd/x11/display_server_x11.h
@@ -159,7 +159,15 @@ class DisplayServerX11 : public DisplayServer {
 	FreeDesktopPortalDesktop *portal_desktop = nullptr;
 #endif
 
+	struct DecorData {
+		Vector<Vector2> region;
+		WindowDecorationType dec_type = WINDOW_DECORATION_MOVE;
+	};
+
 	struct WindowData {
+		int decor_id = 0;
+		HashMap<int, DecorData> decor;
+
 		Window x11_window;
 		Window x11_xim_window;
 		Window parent;
@@ -357,6 +365,8 @@ class DisplayServerX11 : public DisplayServer {
 	static void _dispatch_input_events(const Ref<InputEvent> &p_event);
 	void _dispatch_input_event(const Ref<InputEvent> &p_event);
 
+	void _process_window_drag(WindowID p_window, XEvent p_event, int p_dec_type);
+
 	mutable Mutex events_mutex;
 	Thread events_thread;
 	SafeFlag events_thread_done;
@@ -449,6 +459,10 @@ public:
 
 	virtual void window_set_title(const String &p_title, WindowID p_window = MAIN_WINDOW_ID) override;
 	virtual void window_set_mouse_passthrough(const Vector<Vector2> &p_region, WindowID p_window = MAIN_WINDOW_ID) override;
+
+	virtual int window_add_decoration(const Vector<Vector2> &p_region, WindowDecorationType p_dec_type, WindowID p_window = MAIN_WINDOW_ID) override;
+	virtual void window_change_decoration(int p_rect_id, const Vector<Vector2> &p_region, WindowDecorationType p_dec_type, WindowID p_window = MAIN_WINDOW_ID) override;
+	virtual void window_remove_decoration(int p_rect_id, WindowID p_window = MAIN_WINDOW_ID) override;
 
 	virtual void window_set_rect_changed_callback(const Callable &p_callable, WindowID p_window = MAIN_WINDOW_ID) override;
 	virtual void window_set_window_event_callback(const Callable &p_callable, WindowID p_window = MAIN_WINDOW_ID) override;

--- a/platform/macos/display_server_macos.h
+++ b/platform/macos/display_server_macos.h
@@ -75,7 +75,15 @@ public:
 		uint32_t unicode = 0;
 	};
 
+	struct DecorData {
+		Vector<Vector2> region;
+		WindowDecorationType dec_type = WINDOW_DECORATION_MOVE;
+	};
+
 	struct WindowData {
+		int decor_id = 0;
+		HashMap<int, DecorData> decor;
+
 		id window_delegate;
 		id window_object;
 		id window_view;
@@ -388,6 +396,10 @@ public:
 	virtual void window_set_title(const String &p_title, WindowID p_window = MAIN_WINDOW_ID) override;
 	virtual Size2i window_get_title_size(const String &p_title, WindowID p_window) const override;
 	virtual void window_set_mouse_passthrough(const Vector<Vector2> &p_region, WindowID p_window = MAIN_WINDOW_ID) override;
+
+	virtual int window_add_decoration(const Vector<Vector2> &p_region, WindowDecorationType p_dec_type, WindowID p_window = MAIN_WINDOW_ID) override;
+	virtual void window_change_decoration(int p_rect_id, const Vector<Vector2> &p_region, WindowDecorationType p_dec_type, WindowID p_window = MAIN_WINDOW_ID) override;
+	virtual void window_remove_decoration(int p_rect_id, WindowID p_window = MAIN_WINDOW_ID) override;
 
 	virtual int window_get_current_screen(WindowID p_window = MAIN_WINDOW_ID) const override;
 	virtual void window_set_current_screen(int p_screen, WindowID p_window = MAIN_WINDOW_ID) override;

--- a/platform/macos/display_server_macos.mm
+++ b/platform/macos/display_server_macos.mm
@@ -808,6 +808,7 @@ bool DisplayServerMacOS::has_feature(Feature p_feature) const {
 		case FEATURE_TEXT_TO_SPEECH:
 		case FEATURE_EXTEND_TO_TITLE:
 		case FEATURE_SCREEN_CAPTURE:
+		case FEATURE_CLIENT_SIDE_DECORATIONS:
 			return true;
 		default: {
 		}
@@ -2939,6 +2940,44 @@ void DisplayServerMacOS::window_set_mouse_passthrough(const Vector<Vector2> &p_r
 	wd.mpath = p_region;
 }
 
+int DisplayServerMacOS::window_add_decoration(const Vector<Vector2> &p_region, DisplayServer::WindowDecorationType p_dec_type, WindowID p_window) {
+	_THREAD_SAFE_METHOD_
+
+	ERR_FAIL_INDEX_V(p_dec_type, DisplayServer::WINDOW_DECORATION_MAX, -1);
+	ERR_FAIL_COND_V(!windows.has(p_window), -1);
+	WindowData &wd = windows[p_window];
+
+	int did = wd.decor_id++;
+	wd.decor[did].region = p_region;
+	wd.decor[did].dec_type = p_dec_type;
+
+	return did;
+}
+
+void DisplayServerMacOS::window_change_decoration(int p_rect_id, const Vector<Vector2> &p_region, DisplayServer::WindowDecorationType p_dec_type, WindowID p_window) {
+	_THREAD_SAFE_METHOD_
+
+	ERR_FAIL_INDEX(p_dec_type, DisplayServer::WINDOW_DECORATION_MAX);
+	ERR_FAIL_COND(!windows.has(p_window));
+	WindowData &wd = windows[p_window];
+
+	if (wd.decor.has(p_rect_id)) {
+		wd.decor[p_rect_id].region = p_region;
+		wd.decor[p_rect_id].dec_type = p_dec_type;
+	}
+}
+
+void DisplayServerMacOS::window_remove_decoration(int p_rect_id, WindowID p_window) {
+	_THREAD_SAFE_METHOD_
+
+	ERR_FAIL_COND(!windows.has(p_window));
+	WindowData &wd = windows[p_window];
+
+	if (wd.decor.has(p_rect_id)) {
+		wd.decor.erase(p_rect_id);
+	}
+}
+
 int DisplayServerMacOS::window_get_current_screen(WindowID p_window) const {
 	_THREAD_SAFE_METHOD_
 	ERR_FAIL_COND_V(!windows.has(p_window), -1);
@@ -3310,6 +3349,9 @@ void DisplayServerMacOS::window_set_mode(WindowMode p_mode, WindowID p_window) {
 		} break;
 		case WINDOW_MODE_MAXIMIZED: {
 			if (NSEqualRects([wd.window_object frame], [[wd.window_object screen] visibleFrame])) {
+				if (!([wd.window_object styleMask] & NSWindowStyleMaskTitled)) { // Window should be resizable to zoom.
+					[wd.window_object setStyleMask:[wd.window_object styleMask] | NSWindowStyleMaskResizable];
+				}
 				[wd.window_object zoom:nil];
 			}
 		} break;
@@ -3320,7 +3362,7 @@ void DisplayServerMacOS::window_set_mode(WindowMode p_mode, WindowID p_window) {
 			// Do nothing.
 		} break;
 		case WINDOW_MODE_MINIMIZED: {
-			[wd.window_object performMiniaturize:nil];
+			[wd.window_object miniaturize:nil];
 		} break;
 		case WINDOW_MODE_EXCLUSIVE_FULLSCREEN:
 		case WINDOW_MODE_FULLSCREEN: {
@@ -3343,6 +3385,9 @@ void DisplayServerMacOS::window_set_mode(WindowMode p_mode, WindowID p_window) {
 		} break;
 		case WINDOW_MODE_MAXIMIZED: {
 			if (!NSEqualRects([wd.window_object frame], [[wd.window_object screen] visibleFrame])) {
+				if (!([wd.window_object styleMask] & NSWindowStyleMaskTitled)) { // Window should be resizable to zoom.
+					[wd.window_object setStyleMask:[wd.window_object styleMask] | NSWindowStyleMaskResizable];
+				}
 				[wd.window_object zoom:nil];
 			}
 		} break;
@@ -3362,6 +3407,7 @@ DisplayServer::WindowMode DisplayServerMacOS::window_get_mode(WindowID p_window)
 			return WINDOW_MODE_FULLSCREEN;
 		}
 	}
+
 	if (NSEqualRects([wd.window_object frame], [[wd.window_object screen] visibleFrame])) {
 		return WINDOW_MODE_MAXIMIZED;
 	}
@@ -3511,7 +3557,7 @@ void DisplayServerMacOS::window_set_flag(WindowFlags p_flag, bool p_enabled, Win
 			}
 			wd.borderless = p_enabled;
 			if (p_enabled) {
-				[wd.window_object setStyleMask:NSWindowStyleMaskBorderless];
+				[wd.window_object setStyleMask:NSWindowStyleMaskBorderless | NSWindowStyleMaskMiniaturizable];
 			} else {
 				if (wd.layered_window) {
 					wd.layered_window = false;
@@ -3550,7 +3596,7 @@ void DisplayServerMacOS::window_set_flag(WindowFlags p_flag, bool p_enabled, Win
 				return;
 			}
 			if (p_enabled) {
-				[wd.window_object setStyleMask:NSWindowStyleMaskBorderless]; // Force borderless.
+				[wd.window_object setStyleMask:NSWindowStyleMaskBorderless | NSWindowStyleMaskMiniaturizable]; // Force borderless.
 			} else if (!wd.borderless) {
 				[wd.window_object setStyleMask:NSWindowStyleMaskTitled | NSWindowStyleMaskClosable | NSWindowStyleMaskMiniaturizable | (wd.extend_to_title ? NSWindowStyleMaskFullSizeContentView : 0) | (wd.resize_disabled ? 0 : NSWindowStyleMaskResizable)];
 			}
@@ -3591,7 +3637,7 @@ bool DisplayServerMacOS::window_get_flag(WindowFlags p_flag, WindowID p_window) 
 			return [wd.window_object styleMask] & NSWindowStyleMaskFullSizeContentView;
 		} break;
 		case WINDOW_FLAG_BORDERLESS: {
-			return [wd.window_object styleMask] == NSWindowStyleMaskBorderless;
+			return !([wd.window_object styleMask] & NSWindowStyleMaskTitled);
 		} break;
 		case WINDOW_FLAG_ALWAYS_ON_TOP: {
 			if (wd.fullscreen) {

--- a/platform/macos/godot_content_view.h
+++ b/platform/macos/godot_content_view.h
@@ -68,8 +68,10 @@
 	bool last_pen_inverted;
 	bool ime_suppress_next_keyup;
 	id layer_delegate;
+	DisplayServer::WindowDecorationType current_drag;
 }
 
+- (void)processWindowDrag:(NSEvent *)event drag:(DisplayServer::WindowDecorationType)drag;
 - (void)processScrollEvent:(NSEvent *)event button:(MouseButton)button factor:(double)factor;
 - (void)processPanEvent:(NSEvent *)event dx:(double)dx dy:(double)dy;
 - (void)processMouseEvent:(NSEvent *)event index:(MouseButton)index pressed:(bool)pressed;

--- a/platform/macos/godot_window_delegate.mm
+++ b/platform/macos/godot_window_delegate.mm
@@ -261,6 +261,10 @@
 	wd.size.width = content_rect.size.width * scale;
 	wd.size.height = content_rect.size.height * scale;
 
+	if (!([wd.window_object styleMask] & NSWindowStyleMaskTitled)) {
+		[wd.window_object setStyleMask:[wd.window_object styleMask] & ~NSWindowStyleMaskResizable];
+	}
+
 	CALayer *layer = [wd.window_view layer];
 	if (layer) {
 		layer.contentsScale = scale;

--- a/platform/windows/display_server_windows.h
+++ b/platform/windows/display_server_windows.h
@@ -358,11 +358,21 @@ class DisplayServerWindows : public DisplayServer {
 
 	TTS_Windows *tts = nullptr;
 
+	struct DecorData {
+		Vector<Vector2> region;
+		WindowDecorationType dec_type = WINDOW_DECORATION_MOVE;
+	};
+
 	struct WindowData {
+		int decor_id = 0;
+		HashMap<int, DecorData> decor;
+
 		HWND hWnd;
 
 		Vector<Vector2> mpath;
 
+		bool pre_max_valid = false;
+		RECT pre_max_rect;
 		bool pre_fs_valid = false;
 		RECT pre_fs_rect;
 		bool maximized = false;
@@ -574,6 +584,10 @@ public:
 	virtual Size2i window_get_title_size(const String &p_title, WindowID p_window = MAIN_WINDOW_ID) const override;
 	virtual void window_set_mouse_passthrough(const Vector<Vector2> &p_region, WindowID p_window = MAIN_WINDOW_ID) override;
 
+	virtual int window_add_decoration(const Vector<Vector2> &p_region, WindowDecorationType p_dec_type, WindowID p_window = MAIN_WINDOW_ID) override;
+	virtual void window_change_decoration(int p_rect_id, const Vector<Vector2> &p_region, WindowDecorationType p_dec_type, WindowID p_window = MAIN_WINDOW_ID) override;
+	virtual void window_remove_decoration(int p_rect_id, WindowID p_window = MAIN_WINDOW_ID) override;
+
 	virtual int window_get_current_screen(WindowID p_window = MAIN_WINDOW_ID) const override;
 	virtual void window_set_current_screen(int p_screen, WindowID p_window = MAIN_WINDOW_ID) override;
 
@@ -618,6 +632,9 @@ public:
 
 	virtual void window_set_vsync_mode(DisplayServer::VSyncMode p_vsync_mode, WindowID p_window = MAIN_WINDOW_ID) override;
 	virtual DisplayServer::VSyncMode window_get_vsync_mode(WindowID p_vsync_mode) const override;
+
+	virtual bool window_maximize_on_title_dbl_click() const override;
+	virtual bool window_minimize_on_title_dbl_click() const override;
 
 	virtual void cursor_set_shape(CursorShape p_shape) override;
 	virtual CursorShape cursor_get_shape() const override;

--- a/scene/gui/window_decoration.cpp
+++ b/scene/gui/window_decoration.cpp
@@ -1,0 +1,150 @@
+/**************************************************************************/
+/*  window_decoration.cpp                                                 */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             GODOT ENGINE                               */
+/*                        https://godotengine.org                         */
+/**************************************************************************/
+/* Copyright (c) 2014-present Godot Engine contributors (see AUTHORS.md). */
+/* Copyright (c) 2007-2014 Juan Linietsky, Ariel Manzur.                  */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#include "window_decoration.h"
+
+#include "core/math/geometry_2d.h"
+#include "scene/main/viewport.h"
+#include "scene/main/window.h"
+
+void WindowDecoration::_region_changed() {
+	if (id != -1) {
+		DisplayServer::WindowID wid = get_viewport()->get_window_id();
+		Vector<Point2> polygon_global;
+		if (non_rect && polygon.size() >= 3) {
+			polygon_global = polygon;
+		} else {
+			polygon_global.push_back(Vector2());
+			polygon_global.push_back(Vector2(get_size().x, 0));
+			polygon_global.push_back(get_size());
+			polygon_global.push_back(Vector2(0, get_size().y));
+		}
+		Transform2D t = get_global_transform();
+		for (Vector2 &E : polygon_global) {
+			E = t.xform(E);
+		}
+		DisplayServer::get_singleton()->window_change_decoration(id, polygon_global, dec_type, wid);
+	}
+}
+
+void WindowDecoration::_bind_methods() {
+	ClassDB::bind_method(D_METHOD("set_non_rectangular_region", "non_rect"), &WindowDecoration::set_non_rectangular_region);
+	ClassDB::bind_method(D_METHOD("is_non_rectangular_region"), &WindowDecoration::is_non_rectangular_region);
+
+	ClassDB::bind_method(D_METHOD("set_polygon", "polygon"), &WindowDecoration::set_polygon);
+	ClassDB::bind_method(D_METHOD("get_polygon"), &WindowDecoration::get_polygon);
+
+	ClassDB::bind_method(D_METHOD("set_decoration_type", "pressed"), &WindowDecoration::set_decoration_type);
+	ClassDB::bind_method(D_METHOD("get_decoration_type"), &WindowDecoration::get_decoration_type);
+
+	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "non_rectangular_region"), "set_non_rectangular_region", "is_non_rectangular_region");
+	ADD_PROPERTY(PropertyInfo(Variant::PACKED_VECTOR2_ARRAY, "polygon"), "set_polygon", "get_polygon");
+	ADD_PROPERTY(PropertyInfo(Variant::INT, "decoration_type", PROPERTY_HINT_ENUM, "Resize Top-Left,Resize Top,Resize Top-Right,Resize Left,Resize Right,Resize Bottom-Left,Resize Bottom,Resize Bottom-Right,Move"), "set_decoration_type", "get_decoration_type");
+}
+
+void WindowDecoration::_notification(int p_what) {
+	switch (p_what) {
+		case NOTIFICATION_ENTER_TREE: {
+#ifdef TOOLS_ENABLED
+			if (is_part_of_edited_scene()) {
+				break;
+			}
+#endif
+			if (DisplayServer::get_singleton()->has_feature(DisplayServer::FEATURE_CLIENT_SIDE_DECORATIONS)) {
+				DisplayServer::WindowID wid = get_viewport()->get_window_id();
+				if (id != -1) {
+					DisplayServer::get_singleton()->window_remove_decoration(id, wid);
+				}
+				Vector<Point2> polygon_global;
+				if (non_rect && polygon.size() >= 3) {
+					polygon_global = polygon;
+				} else {
+					polygon_global.push_back(Vector2());
+					polygon_global.push_back(Vector2(get_size().x, 0));
+					polygon_global.push_back(get_size());
+					polygon_global.push_back(Vector2(0, get_size().y));
+				}
+				Transform2D t = get_global_transform();
+				for (Vector2 &E : polygon_global) {
+					E = t.xform(E);
+				}
+				id = DisplayServer::get_singleton()->window_add_decoration(polygon_global, dec_type, wid);
+			}
+		} break;
+
+		case NOTIFICATION_EXIT_TREE: {
+			if (id != -1) {
+				DisplayServer::WindowID wid = get_viewport()->get_window_id();
+				DisplayServer::get_singleton()->window_remove_decoration(id, wid);
+				id = -1;
+			}
+		} break;
+
+		default:
+			break;
+	}
+}
+
+void WindowDecoration::set_non_rectangular_region(bool p_non_rect) {
+	non_rect = p_non_rect;
+	_region_changed();
+}
+
+bool WindowDecoration::is_non_rectangular_region() const {
+	return non_rect;
+}
+
+void WindowDecoration::set_polygon(const Vector<Point2> &p_polygon) {
+	polygon = p_polygon;
+	_region_changed();
+}
+
+Vector<Point2> WindowDecoration::get_polygon() const {
+	return polygon;
+}
+
+void WindowDecoration::set_decoration_type(DisplayServer::WindowDecorationType p_dec_type) {
+	ERR_FAIL_INDEX(p_dec_type, DisplayServer::WINDOW_DECORATION_MAX);
+
+	if (dec_type == p_dec_type) {
+		return;
+	}
+
+	dec_type = p_dec_type;
+	_region_changed();
+}
+
+DisplayServer::WindowDecorationType WindowDecoration::get_decoration_type() const {
+	return dec_type;
+}
+
+WindowDecoration::WindowDecoration() {
+	connect("item_rect_changed", callable_mp(this, &WindowDecoration::_region_changed), CONNECT_DEFERRED);
+}

--- a/scene/gui/window_decoration.h
+++ b/scene/gui/window_decoration.h
@@ -1,5 +1,5 @@
 /**************************************************************************/
-/*  line_2d_editor_plugin.cpp                                             */
+/*  window_decoration.h                                                   */
 /**************************************************************************/
 /*                         This file is part of:                          */
 /*                             GODOT ENGINE                               */
@@ -28,40 +28,37 @@
 /* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
 /**************************************************************************/
 
-#include "line_2d_editor_plugin.h"
+#ifndef WINDOW_DECORATION_H
+#define WINDOW_DECORATION_H
 
-#include "editor/editor_node.h"
-#include "editor/editor_undo_redo_manager.h"
+#include "scene/gui/control.h"
 
-CanvasItem *Line2DEditor::_get_node() const {
-	return node;
-}
+class WindowDecoration : public Control {
+	GDCLASS(WindowDecoration, Control);
 
-void Line2DEditor::_set_node(Node *p_line) {
-	node = Object::cast_to<Line2D>(p_line);
-}
+private:
+	DisplayServer::WindowDecorationType dec_type = DisplayServer::WINDOW_DECORATION_MOVE;
+	int id = -1;
+	bool non_rect = false;
+	Vector<Point2> polygon;
 
-bool Line2DEditor::_is_line() const {
-	return true;
-}
+	void _region_changed();
 
-Variant Line2DEditor::_get_polygon(int p_idx) const {
-	return _get_node()->get("points");
-}
+protected:
+	static void _bind_methods();
+	void _notification(int p_what);
 
-void Line2DEditor::_set_polygon(int p_idx, const Variant &p_polygon) const {
-	_get_node()->set("points", p_polygon);
-}
+public:
+	void set_decoration_type(DisplayServer::WindowDecorationType p_dec_type);
+	DisplayServer::WindowDecorationType get_decoration_type() const;
 
-void Line2DEditor::_action_set_polygon(int p_idx, const Variant &p_previous, const Variant &p_polygon) {
-	CanvasItem *_node = _get_node();
-	EditorUndoRedoManager *undo_redo = EditorUndoRedoManager::get_singleton();
-	undo_redo->add_do_method(_node, "set_points", p_polygon);
-	undo_redo->add_undo_method(_node, "set_points", p_previous);
-}
+	void set_non_rectangular_region(bool p_non_rect);
+	bool is_non_rectangular_region() const;
 
-Line2DEditor::Line2DEditor() {}
+	void set_polygon(const Vector<Point2> &p_polygon);
+	Vector<Point2> get_polygon() const;
 
-Line2DEditorPlugin::Line2DEditorPlugin() :
-		AbstractPolygon2DEditorPlugin(memnew(Line2DEditor), "Line2D") {
-}
+	WindowDecoration();
+};
+
+#endif // WINDOW_DECORATION_H

--- a/scene/main/canvas_item.cpp
+++ b/scene/main/canvas_item.cpp
@@ -1054,6 +1054,11 @@ Vector2 CanvasItem::get_local_mouse_position() const {
 	return get_global_transform().affine_inverse().xform(get_global_mouse_position());
 }
 
+Point2 CanvasItem::to_local(Point2 p_global) const {
+	ERR_READ_THREAD_GUARD_V(Point2());
+	return get_global_transform().affine_inverse().xform(p_global);
+}
+
 void CanvasItem::force_update_transform() {
 	ERR_THREAD_GUARD;
 	ERR_FAIL_COND(!is_inside_tree());

--- a/scene/main/canvas_item.h
+++ b/scene/main/canvas_item.h
@@ -342,6 +342,8 @@ public:
 	Vector2 get_global_mouse_position() const;
 	Vector2 get_local_mouse_position() const;
 
+	Point2 to_local(Point2 p_global) const;
+
 	void set_notify_local_transform(bool p_enable);
 	bool is_local_transform_notification_enabled() const;
 

--- a/scene/register_scene_types.cpp
+++ b/scene/register_scene_types.cpp
@@ -129,6 +129,7 @@
 #include "scene/gui/texture_rect.h"
 #include "scene/gui/tree.h"
 #include "scene/gui/video_stream_player.h"
+#include "scene/gui/window_decoration.h"
 #include "scene/main/canvas_item.h"
 #include "scene/main/canvas_layer.h"
 #include "scene/main/http_request.h"
@@ -349,6 +350,7 @@ void register_scene_types() {
 	GDREGISTER_CLASS(CanvasModulate);
 	GDREGISTER_CLASS(ResourcePreloader);
 	GDREGISTER_CLASS(Window);
+	GDREGISTER_CLASS(WindowDecoration);
 
 	/* REGISTER GUI */
 

--- a/servers/display_server.cpp
+++ b/servers/display_server.cpp
@@ -460,6 +460,18 @@ void DisplayServer::window_set_mouse_passthrough(const Vector<Vector2> &p_region
 	ERR_FAIL_MSG("Mouse passthrough not supported by this display server.");
 }
 
+int DisplayServer::window_add_decoration(const Vector<Vector2> &p_region, DisplayServer::WindowDecorationType p_dec_type, WindowID p_window) {
+	ERR_FAIL_V_MSG(-1, "Client side decorations are not supported by this display server.");
+}
+
+void DisplayServer::window_change_decoration(int p_rect_id, const Vector<Vector2> &p_region, DisplayServer::WindowDecorationType p_dec_type, WindowID p_window) {
+	ERR_FAIL_MSG("Client side decorations are not supported by this display server.");
+}
+
+void DisplayServer::window_remove_decoration(int p_rect_id, WindowID p_window) {
+	ERR_FAIL_MSG("Client side decorations are not supported by this display server.");
+}
+
 void DisplayServer::gl_window_make_current(DisplayServer::WindowID p_window_id) {
 	// noop except in gles
 }
@@ -720,6 +732,10 @@ void DisplayServer::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("window_get_title_size", "title", "window_id"), &DisplayServer::window_get_title_size, DEFVAL(MAIN_WINDOW_ID));
 	ClassDB::bind_method(D_METHOD("window_set_mouse_passthrough", "region", "window_id"), &DisplayServer::window_set_mouse_passthrough, DEFVAL(MAIN_WINDOW_ID));
 
+	ClassDB::bind_method(D_METHOD("window_add_decoration", "region", "dec_type", "window"), &DisplayServer::window_add_decoration, DEFVAL(MAIN_WINDOW_ID));
+	ClassDB::bind_method(D_METHOD("window_change_decoration", "rect_id", "region", "dec_type", "window"), &DisplayServer::window_change_decoration, DEFVAL(MAIN_WINDOW_ID));
+	ClassDB::bind_method(D_METHOD("window_remove_decoration", "rect_id", "window"), &DisplayServer::window_remove_decoration, DEFVAL(MAIN_WINDOW_ID));
+
 	ClassDB::bind_method(D_METHOD("window_get_current_screen", "window_id"), &DisplayServer::window_get_current_screen, DEFVAL(MAIN_WINDOW_ID));
 	ClassDB::bind_method(D_METHOD("window_set_current_screen", "screen", "window_id"), &DisplayServer::window_set_current_screen, DEFVAL(MAIN_WINDOW_ID));
 
@@ -834,6 +850,7 @@ void DisplayServer::_bind_methods() {
 	BIND_ENUM_CONSTANT(FEATURE_TEXT_TO_SPEECH);
 	BIND_ENUM_CONSTANT(FEATURE_EXTEND_TO_TITLE);
 	BIND_ENUM_CONSTANT(FEATURE_SCREEN_CAPTURE);
+	BIND_ENUM_CONSTANT(FEATURE_CLIENT_SIDE_DECORATIONS);
 
 	BIND_ENUM_CONSTANT(MOUSE_MODE_VISIBLE);
 	BIND_ENUM_CONSTANT(MOUSE_MODE_HIDDEN);
@@ -915,6 +932,16 @@ void DisplayServer::_bind_methods() {
 	BIND_ENUM_CONSTANT(WINDOW_EVENT_GO_BACK_REQUEST);
 	BIND_ENUM_CONSTANT(WINDOW_EVENT_DPI_CHANGE);
 	BIND_ENUM_CONSTANT(WINDOW_EVENT_TITLEBAR_CHANGE);
+
+	BIND_ENUM_CONSTANT(WINDOW_DECORATION_TOP_LEFT);
+	BIND_ENUM_CONSTANT(WINDOW_DECORATION_TOP);
+	BIND_ENUM_CONSTANT(WINDOW_DECORATION_TOP_RIGHT);
+	BIND_ENUM_CONSTANT(WINDOW_DECORATION_LEFT);
+	BIND_ENUM_CONSTANT(WINDOW_DECORATION_RIGHT);
+	BIND_ENUM_CONSTANT(WINDOW_DECORATION_BOTTOM_LEFT);
+	BIND_ENUM_CONSTANT(WINDOW_DECORATION_BOTTOM);
+	BIND_ENUM_CONSTANT(WINDOW_DECORATION_BOTTOM_RIGHT);
+	BIND_ENUM_CONSTANT(WINDOW_DECORATION_MOVE);
 
 	BIND_ENUM_CONSTANT(VSYNC_DISABLED);
 	BIND_ENUM_CONSTANT(VSYNC_ENABLED);

--- a/servers/display_server.h
+++ b/servers/display_server.h
@@ -125,6 +125,7 @@ public:
 		FEATURE_TEXT_TO_SPEECH,
 		FEATURE_EXTEND_TO_TITLE,
 		FEATURE_SCREEN_CAPTURE,
+		FEATURE_CLIENT_SIDE_DECORATIONS,
 	};
 
 	virtual bool has_feature(Feature p_feature) const = 0;
@@ -399,6 +400,23 @@ public:
 
 	virtual void window_set_mouse_passthrough(const Vector<Vector2> &p_region, WindowID p_window = MAIN_WINDOW_ID);
 
+	enum WindowDecorationType {
+		WINDOW_DECORATION_TOP_LEFT,
+		WINDOW_DECORATION_TOP,
+		WINDOW_DECORATION_TOP_RIGHT,
+		WINDOW_DECORATION_LEFT,
+		WINDOW_DECORATION_RIGHT,
+		WINDOW_DECORATION_BOTTOM_LEFT,
+		WINDOW_DECORATION_BOTTOM,
+		WINDOW_DECORATION_BOTTOM_RIGHT,
+		WINDOW_DECORATION_MOVE,
+		WINDOW_DECORATION_MAX,
+	};
+
+	virtual int window_add_decoration(const Vector<Vector2> &p_region, WindowDecorationType p_dec_type, WindowID p_window = MAIN_WINDOW_ID);
+	virtual void window_change_decoration(int p_rect_id, const Vector<Vector2> &p_region, WindowDecorationType p_dec_type, WindowID p_window = MAIN_WINDOW_ID);
+	virtual void window_remove_decoration(int p_rect_id, WindowID p_window = MAIN_WINDOW_ID);
+
 	virtual int window_get_current_screen(WindowID p_window = MAIN_WINDOW_ID) const = 0;
 	virtual void window_set_current_screen(int p_screen, WindowID p_window = MAIN_WINDOW_ID) = 0;
 
@@ -554,6 +572,7 @@ public:
 };
 
 VARIANT_ENUM_CAST(DisplayServer::WindowEvent)
+VARIANT_ENUM_CAST(DisplayServer::WindowDecorationType)
 VARIANT_ENUM_CAST(DisplayServer::Feature)
 VARIANT_ENUM_CAST(DisplayServer::MouseMode)
 VARIANT_ENUM_CAST(DisplayServer::ScreenOrientation)


### PR DESCRIPTION
This removes the break in the move section of the buttonpress statement to allow the input event to propagate to the buttonrelease and be processed as a double click to maximise and restore when double-clicking with the left mouse button. _(Technically, this also allows the input to propagate to the gui_input signal in the editor itself, so you could just comment out the "`drag_event = true;`" and implement it in the engine with a script instead. But I don't think the implementations for the windows and macos displayservers allow that so probably shouldn't have that inconsistency...)_

There is also some weirdness where it sometimes only needs a single button press to maximise or restore upon clicking the move decoration and I'm not _entirely_ sure why. Edit: thinking it's because a triple-click and beyond still count as a double-click, so get counted with this implementation.

This is a very rudimentary implementation _(and probably just plain bad in general)_, but it appears to be _mostly_ functional.

It might also be better to implement it in buttonpress(_that way you can uncomment "`drag_event = true;`" to prevent the input reaching the rest of the engine_) and only apply it upon buttonrelease to match more closely what real titlebars do. But doing that would require implementing a double-click detector that doesn't get broken out of in buttonpress in addition to the one that already exists in buttonrelease